### PR TITLE
feat: add configurable maxKeySize option to Memcache client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ export class Memcache extends Hookified {
 			this._retryOnlyIdempotent = options?.retryOnlyIdempotent ?? true;
 			this._sasl = options?.sasl;
 			this._lazyConnect = options?.lazyConnect ?? true;
-			this._maxKeySize = options?.maxKeySize ?? 250;
+			this._maxKeySize = Math.max(0, Math.floor(options?.maxKeySize ?? 250));
 			this._autoDiscoverOptions = options?.autoDiscover;
 
 			// Add nodes if provided, otherwise add default node
@@ -203,7 +203,7 @@ export class Memcache extends Hookified {
 	 * @default 250
 	 */
 	public set maxKeySize(value: number) {
-		this._maxKeySize = value;
+		this._maxKeySize = Math.max(0, Math.floor(value));
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ export class Memcache extends Hookified {
 	private _autoDiscovery: AutoDiscovery | undefined;
 	private _autoDiscoverOptions: AutoDiscoverOptions | undefined;
 	private readonly _lazyConnect: boolean;
+	private _maxKeySize: number;
 
 	constructor(options?: string | MemcacheOptions) {
 		super({ throwOnEmptyListeners: false });
@@ -87,6 +88,7 @@ export class Memcache extends Hookified {
 			this._retryOnlyIdempotent = true;
 			this._sasl = undefined;
 			this._lazyConnect = true;
+			this._maxKeySize = 250;
 			this.addNode(options);
 		} else {
 			// Handle MemcacheOptions object
@@ -100,6 +102,7 @@ export class Memcache extends Hookified {
 			this._retryOnlyIdempotent = options?.retryOnlyIdempotent ?? true;
 			this._sasl = options?.sasl;
 			this._lazyConnect = options?.lazyConnect ?? true;
+			this._maxKeySize = options?.maxKeySize ?? 250;
 			this._autoDiscoverOptions = options?.autoDiscover;
 
 			// Add nodes if provided, otherwise add default node
@@ -183,6 +186,24 @@ export class Memcache extends Hookified {
 	 */
 	public set timeout(value: number) {
 		this._timeout = value;
+	}
+
+	/**
+	 * Get the maximum allowed key size (in characters).
+	 * @returns {number}
+	 * @default 250
+	 */
+	public get maxKeySize(): number {
+		return this._maxKeySize;
+	}
+
+	/**
+	 * Set the maximum allowed key size (in characters). Memcache protocol max is 250.
+	 * @param {number} value
+	 * @default 250
+	 */
+	public set maxKeySize(value: number) {
+		this._maxKeySize = value;
 	}
 
 	/**
@@ -1199,7 +1220,7 @@ export class Memcache extends Hookified {
 	/**
 	 * Validates a Memcache key according to protocol requirements.
 	 * @param {string} key - The key to validate
-	 * @throws {Error} If the key is empty, exceeds 250 characters, or contains invalid characters
+	 * @throws {Error} If the key is empty, exceeds `maxKeySize` characters, or contains invalid characters
 	 *
 	 * @example
 	 * ```typescript
@@ -1213,8 +1234,10 @@ export class Memcache extends Hookified {
 		if (!key || key.length === 0) {
 			throw new Error("Key cannot be empty");
 		}
-		if (key.length > 250) {
-			throw new Error("Key length cannot exceed 250 characters");
+		if (key.length > this._maxKeySize) {
+			throw new Error(
+				`Key length cannot exceed ${this._maxKeySize} characters`,
+			);
 		}
 		if (KEY_INVALID_CHARS.test(key)) {
 			throw new Error(

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,12 @@ export interface MemcacheOptions {
 	lazyConnect?: boolean;
 
 	/**
+	 * The maximum allowed key size (in characters). Memcache protocol max is 250.
+	 * @default 250
+	 */
+	maxKeySize?: number;
+
+	/**
 	 * AWS ElastiCache Auto Discovery configuration.
 	 * When enabled, the client will periodically poll the configuration endpoint
 	 * to detect cluster topology changes and automatically update the node list.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -817,6 +817,27 @@ describe("Memcache", () => {
 				"Key cannot contain spaces, newlines, or null characters",
 			);
 		});
+
+		it("should default maxKeySize to 250", () => {
+			expect(client.maxKeySize).toBe(250);
+		});
+
+		it("should honor maxKeySize passed via constructor options", () => {
+			const customClient = new Memcache({ maxKeySize: 10 });
+			expect(customClient.maxKeySize).toBe(10);
+			expect(() => customClient.validateKey("a".repeat(11))).toThrow(
+				"Key length cannot exceed 10 characters",
+			);
+			expect(() => customClient.validateKey("a".repeat(10))).not.toThrow();
+		});
+
+		it("should honor maxKeySize updated via setter", () => {
+			client.maxKeySize = 5;
+			expect(client.maxKeySize).toBe(5);
+			expect(() => client.validateKey("abcdef")).toThrow(
+				"Key length cannot exceed 5 characters",
+			);
+		});
 	});
 
 	describe("Connection Management", () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?**

Feature - Adds a configurable `maxKeySize` option to the Memcache client.

**Description**

This PR introduces a new `maxKeySize` configuration option that allows users to customize the maximum allowed key size for their Memcache operations. Previously, the key size limit was hardcoded to 250 characters (the Memcache protocol maximum).

**Changes**

- Added `_maxKeySize` private property to the `Memcache` class with a default value of 250
- Added `maxKeySize` getter and setter for runtime configuration
- Added `maxKeySize` option to `MemcacheOptions` interface
- Updated `validateKey()` method to use the configurable `_maxKeySize` instead of the hardcoded 250 limit
- Updated JSDoc comments to reference the configurable limit
- Added comprehensive unit tests covering:
  - Default value of 250
  - Constructor option initialization
  - Runtime setter updates
  - Validation behavior with custom limits

**Test Plan**

Added unit tests that verify:
1. Default `maxKeySize` is 250
2. Custom `maxKeySize` can be passed via constructor options
3. `maxKeySize` can be updated via the setter
4. Key validation respects the configured limit

All tests pass with 100% code coverage for the new functionality.

https://claude.ai/code/session_01P78sD9fmRPbxPgLQFCZDBT