### PR TITLE
memcache - fix: upgrade hookified

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "hookified": "^2.1.1"
+    "hookified": "^2.2.0"
   },
   "files": [
     "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       hookified:
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.14
@@ -1444,8 +1444,8 @@ packages:
   hookified@1.15.1:
     resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
-  hookified@2.1.1:
-    resolution: {integrity: sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==}
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
 
   html-dom-parser@5.1.8:
     resolution: {integrity: sha512-MCIUng//mF2qTtGHXJWr6OLfHWmg3Pm8ezpfiltF83tizPWY17JxT4dRLE8lykJ5bChJELoY3onQKPbufJHxYA==}
@@ -3361,7 +3361,7 @@ snapshots:
       cacheable: 2.3.4
       ejs: 5.0.2
       ent: 2.2.2
-      hookified: 2.1.1
+      hookified: 2.2.0
       liquidjs: 10.25.5
       nunjucks: 3.2.4
       pug: 3.0.4
@@ -3567,7 +3567,7 @@ snapshots:
 
   hashery@2.0.0:
     dependencies:
-      hookified: 2.1.1
+      hookified: 2.2.0
 
   hashring@3.2.0:
     dependencies:
@@ -3692,7 +3692,7 @@ snapshots:
 
   hookified@1.15.1: {}
 
-  hookified@2.1.1: {}
+  hookified@2.2.0: {}
 
   html-dom-parser@5.1.8:
     dependencies:
@@ -4518,7 +4518,7 @@ snapshots:
 
   qified@0.9.1:
     dependencies:
-      hookified: 2.1.1
+      hookified: 2.2.0
 
   quansync@1.0.0: {}
 
@@ -5079,7 +5079,7 @@ snapshots:
       ai: 6.0.168(zod@4.3.6)
       cacheable: 2.3.4
       hashery: 1.5.1
-      hookified: 2.1.1
+      hookified: 2.2.0
       html-react-parser: 5.2.17(react@19.2.5)
       js-yaml: 4.1.1
       react: 19.2.5


### PR DESCRIPTION
## Summary
Upgrade the `hookified` runtime dependency.

- `hookified` `2.1.1` → `2.2.0`

Single runtime dependency upgrade. Minor version bump within the existing 2.x major.

Rebased on `main` after #78 merged; the bundled pnpm-workspace fix commit was a no-op on rebase (already in `main`) and was dropped automatically.

## Test plan
- [x] `pnpm install` resolves cleanly
- [x] `pnpm build` succeeds
- [x] `pnpm test` succeeds (577/577 tests pass)