### PR TITLE
memcache - fix: upgrade tinybench

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "memcached": "^2.2.2",
     "memjs": "^1.3.2",
     "rimraf": "^6.1.3",
-    "tinybench": "^6.0.0",
+    "tinybench": "^6.0.1",
     "tsdown": "^0.21.7",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
         version: 10.4.0
       '@monstermann/tinybench-pretty-printer':
         specifier: ^0.3.0
-        version: 0.3.0(tinybench@6.0.0)
+        version: 0.3.0(tinybench@6.0.1)
       '@types/memcached':
         specifier: ^2.2.10
         version: 2.2.10
@@ -46,8 +46,8 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       tinybench:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.0.1
+        version: 6.0.1
       tsdown:
         specifier: ^0.21.7
         version: 0.21.7(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(typescript@6.0.2)
@@ -2197,8 +2197,8 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinybench@6.0.0:
-    resolution: {integrity: sha512-BWlWpVbbZXaYjRV0twGLNQO00Zj4HA/sjLOQP2IvzQqGwRGp+2kh7UU3ijyJ3ywFRogYDRbiHDMrUOfaMnN56g==}
+  tinybench@6.0.1:
+    resolution: {integrity: sha512-cMdWsxmysdg8mNWf1pujiWl3TW0cU6m8QuNw55QlnP3I6N96Grb0wnu5N0syHIu3LbiVZCNqlfWzWDq84HZphA==}
     engines: {node: '>=20.0.0'}
 
   tinyexec@1.1.1:
@@ -2819,11 +2819,11 @@ snapshots:
       picocolors: 1.1.1
       string-width: 7.2.0
 
-  '@monstermann/tinybench-pretty-printer@0.3.0(tinybench@6.0.0)':
+  '@monstermann/tinybench-pretty-printer@0.3.0(tinybench@6.0.1)':
     dependencies:
       '@monstermann/tables': 0.0.0
       picocolors: 1.1.1
-      tinybench: 6.0.0
+      tinybench: 6.0.1
 
   '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
@@ -4838,7 +4838,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinybench@6.0.0: {}
+  tinybench@6.0.1: {}
 
   tinyexec@1.1.1: {}
 


### PR DESCRIPTION
## Summary
Upgrade `tinybench` benchmarking utility.

- `tinybench` `6.0.0` → `6.0.1`

Standalone utility upgrade — patch bump.

Rebased on `main` after #78 merged; the bundled pnpm-workspace fix commit was a no-op on rebase (already in `main`) and was dropped automatically.

## Test plan
- [x] `pnpm install` resolves cleanly
- [x] `pnpm build` succeeds
- [x] `pnpm test` succeeds (577/577 tests pass)