### PR TITLE
feat: add hashLargeKey option for keys over maxKeySize

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ const client = new Memcache({
 - `maxKeySize?: number` - Maximum allowed key size in characters (default: 250, memcache protocol max)
 - `maxValueSize?: number` - Maximum allowed value size in bytes (default: 1048576, memcached default)
 - `maxExpiration?: number` - Maximum allowed expiration in seconds (default: 2592000, memcached's 30-day relative-time boundary). Values above this throw. `0` (no expiration) is always allowed. Raise this if you need to pass absolute Unix timestamps as expirations.
+- `hashLargeKey?: boolean` - When `true`, keys longer than `maxKeySize` are deterministically hashed with djb2 (via the [`hashery`](https://github.com/jaredwray/hashery) library) before being sent to the server, instead of throwing. When `false`, oversized keys throw a validation error (default: false). Note: hashing is one-way and can collide; two distinct long keys could map to the same hashed key.
 - `autoDiscover?: AutoDiscoverOptions` - AWS ElastiCache Auto Discovery configuration (see [Auto Discovery](#auto-discovery))
 
 ## Properties
@@ -251,6 +252,16 @@ Get or set the maximum allowed value size in bytes (default: 1048576). Writes (`
 
 ### `maxExpiration: number`
 Get or set the maximum allowed expiration in seconds (default: 2592000). Writes that accept an expiration (`set`, `add`, `replace`, `cas`, `touch`) throw when `exptime` exceeds this limit. `0` (no expiration) is always allowed. Memcached treats any `exptime` greater than 2592000 as an absolute Unix timestamp, so the default guards against accidentally setting a TTL that memcached interprets as "already expired." Raise this if you need to pass Unix timestamps.
+
+### `hashLargeKey: boolean`
+Get or set whether keys exceeding `maxKeySize` are hashed with djb2 instead of throwing (default: false). When enabled, oversized keys are replaced with a short, deterministic djb2 hex digest (via the [`hashery`](https://github.com/jaredwray/hashery) library) before being sent to memcache, so any string length is accepted. The same input always produces the same hashed key, but distinct long keys can collide.
+
+```javascript
+const client = new Memcache({ hashLargeKey: true });
+const longKey = 'user:profile:' + 'x'.repeat(500);
+await client.set(longKey, 'value');     // hashed automatically
+await client.get(longKey);              // same hash, returns 'value'
+```
 
 ### `lazyConnect: boolean` (readonly)
 Whether nodes defer connecting until the first command is executed (default: true).
@@ -363,6 +374,9 @@ Validates a Memcache key according to protocol requirements. Throws error if:
 - Key is empty
 - Key exceeds 250 characters
 - Key contains spaces, newlines, or null characters
+
+### `resolveKey(key: string): string`
+Returns the key that will actually be sent to memcache. When [`hashLargeKey`](#hashlargekey-boolean) is `true` and the key length exceeds `maxKeySize`, returns a djb2 hex digest of the key (8-char hex). Otherwise returns the original key unchanged. Called automatically before `validateKey` in every command, so calling it manually is only needed when you want to inspect the on-wire key.
 
 ## Helper Functions
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ const client = new Memcache({
 - `maxKeySize?: number` - Maximum allowed key size in characters (default: 250, memcache protocol max)
 - `maxValueSize?: number` - Maximum allowed value size in bytes (default: 1048576, memcached default)
 - `maxExpiration?: number` - Maximum allowed expiration in seconds (default: 2592000, memcached's 30-day relative-time boundary). Values above this throw. `0` (no expiration) is always allowed. Raise this if you need to pass absolute Unix timestamps as expirations.
-- `hashLargeKey?: boolean` - When `true`, keys longer than `maxKeySize` are deterministically hashed with djb2 (via the [`hashery`](https://github.com/jaredwray/hashery) library) before being sent to the server, instead of throwing. When `false`, oversized keys throw a validation error (default: false). Note: hashing is one-way and can collide; two distinct long keys could map to the same hashed key.
+- `hashLargeKey?: boolean | Hashery` - When `true`, keys longer than `maxKeySize` are deterministically hashed via [`hashery`](https://github.com/jaredwray/hashery) (djb2 sync by default) before being sent to the server, instead of throwing. Pass a configured `Hashery` instance (e.g. `new Hashery({ defaultAlgorithmSync: 'fnv1' })`) to choose a different sync algorithm or plug in custom providers. When `false`, oversized keys throw a validation error (default: false). Note: hashing is one-way and can collide; two distinct long keys could map to the same hashed key.
 - `autoDiscover?: AutoDiscoverOptions` - AWS ElastiCache Auto Discovery configuration (see [Auto Discovery](#auto-discovery))
 
 ## Properties
@@ -254,13 +254,31 @@ Get or set the maximum allowed value size in bytes (default: 1048576). Writes (`
 Get or set the maximum allowed expiration in seconds (default: 2592000). Writes that accept an expiration (`set`, `add`, `replace`, `cas`, `touch`) throw when `exptime` exceeds this limit. `0` (no expiration) is always allowed. Memcached treats any `exptime` greater than 2592000 as an absolute Unix timestamp, so the default guards against accidentally setting a TTL that memcached interprets as "already expired." Raise this if you need to pass Unix timestamps.
 
 ### `hashLargeKey: boolean`
-Get or set whether keys exceeding `maxKeySize` are hashed with djb2 instead of throwing (default: false). When enabled, oversized keys are replaced with a short, deterministic djb2 hex digest (via the [`hashery`](https://github.com/jaredwray/hashery) library) before being sent to memcache, so any string length is accepted. The same input always produces the same hashed key, but distinct long keys can collide.
+Get or set whether keys exceeding `maxKeySize` are hashed instead of throwing (default: false). When enabled, oversized keys are replaced with a short, deterministic hex digest (via the [`hashery`](https://github.com/jaredwray/hashery) library, djb2 by default) before being sent to memcache, so any string length is accepted. The same input always produces the same hashed key, but distinct long keys can collide. To change algorithm or providers, configure the [`hashery`](#hashery-hashery) property.
 
 ```javascript
 const client = new Memcache({ hashLargeKey: true });
 const longKey = 'user:profile:' + 'x'.repeat(500);
 await client.set(longKey, 'value');     // hashed automatically
 await client.get(longKey);              // same hash, returns 'value'
+```
+
+### `hashery: Hashery`
+Get or set the `Hashery` instance used to hash oversized keys when `hashLargeKey` is enabled. Always returns an instance, even when hashing is disabled, so you can pre-configure it (algorithm, custom providers, caching) before flipping `hashLargeKey` on. `Hashery` is re-exported from this package for convenience.
+
+```javascript
+import Memcache, { Hashery } from 'memcache';
+
+// Simple — defaults to djb2 sync hashing
+const simple = new Memcache({ hashLargeKey: true });
+
+// Advanced — supply a Hashery preconfigured for fnv1
+const advanced = new Memcache({
+  hashLargeKey: new Hashery({ defaultAlgorithmSync: 'fnv1' }),
+});
+
+// Or mutate the instance after construction
+simple.hashery.defaultAlgorithmSync = 'murmur';
 ```
 
 ### `lazyConnect: boolean` (readonly)
@@ -376,7 +394,7 @@ Validates a Memcache key according to protocol requirements. Throws error if:
 - Key contains spaces, newlines, or null characters
 
 ### `resolveKey(key: string): string`
-Returns the key that will actually be sent to memcache. When [`hashLargeKey`](#hashlargekey-boolean) is `true` and the key length exceeds `maxKeySize`, returns a djb2 hex digest of the key (8-char hex). Otherwise returns the original key unchanged. Called automatically before `validateKey` in every command, so calling it manually is only needed when you want to inspect the on-wire key.
+Returns the key that will actually be sent to memcache. When [`hashLargeKey`](#hashlargekey-boolean) is `true` and the key length exceeds `maxKeySize`, returns a short hex digest produced by the configured [`hashery`](#hashery-hashery) instance (djb2 by default — 8 hex chars). Otherwise returns the original key unchanged. Called automatically before `validateKey` in every command, so calling it manually is only needed when you want to inspect the on-wire key.
 
 ## Helper Functions
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
+    "hashery": "^2.0.0",
     "hookified": "^2.2.0"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      hashery:
+        specifier: ^2.0.0
+        version: 2.0.0
       hookified:
         specifier: ^2.2.0
         version: 2.2.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { DJB2 } from "hashery";
+import { Hashery } from "hashery";
 import { Hookified } from "hookified";
 import { AutoDiscovery } from "./auto-discovery.js";
 import { BroadcastHash } from "./broadcast.js";
@@ -49,9 +49,19 @@ export const exponentialRetryBackoff: RetryBackoffFunction = (
 // Pre-compiled regex for key validation (avoid re-compiling per call)
 const KEY_INVALID_CHARS = /[\s\r\n\0]/;
 
-// Shared djb2 hasher and encoder used when hashLargeKey is enabled
-const djb2Hasher = new DJB2();
-const keyEncoder = new TextEncoder();
+/**
+ * Resolve the user-supplied `hashLargeKey` option into the (enabled, hashery)
+ * pair used internally. A boolean value selects/disables the feature with a
+ * fresh Hashery; passing a Hashery instance enables the feature and uses that
+ * instance verbatim.
+ */
+function resolveHashLargeKeyOption(value: boolean | Hashery | undefined): {
+	enabled: boolean;
+	hashery: Hashery;
+} {
+	if (value instanceof Hashery) return { enabled: true, hashery: value };
+	return { enabled: value === true, hashery: new Hashery() };
+}
 
 /**
  * Check if all results match an expected value.
@@ -80,6 +90,7 @@ export class Memcache extends Hookified {
 	private _maxValueSize: number;
 	private _maxExpiration: number;
 	private _hashLargeKey: boolean;
+	private _hashery: Hashery;
 
 	constructor(options?: string | MemcacheOptions) {
 		super({ throwOnEmptyListeners: false });
@@ -99,7 +110,9 @@ export class Memcache extends Hookified {
 			this._maxKeySize = 250;
 			this._maxValueSize = 1048576;
 			this._maxExpiration = 2592000;
-			this._hashLargeKey = false;
+			const stringResolved = resolveHashLargeKeyOption(undefined);
+			this._hashLargeKey = stringResolved.enabled;
+			this._hashery = stringResolved.hashery;
 			this.addNode(options);
 		} else {
 			// Handle MemcacheOptions object
@@ -137,7 +150,9 @@ export class Memcache extends Hookified {
 						: 2592000,
 				),
 			);
-			this._hashLargeKey = options?.hashLargeKey ?? false;
+			const optionsResolved = resolveHashLargeKeyOption(options?.hashLargeKey);
+			this._hashLargeKey = optionsResolved.enabled;
+			this._hashery = optionsResolved.hashery;
 			this._autoDiscoverOptions = options?.autoDiscover;
 
 			// Add nodes if provided, otherwise add default node
@@ -254,14 +269,35 @@ export class Memcache extends Hookified {
 	}
 
 	/**
-	 * Enable or disable djb2 hashing of keys that exceed `maxKeySize`.
-	 * When true, oversized keys are deterministically hashed before validation.
-	 * When false, oversized keys throw a validation error.
+	 * Enable or disable hashing of keys that exceed `maxKeySize`.
+	 * When true, oversized keys are deterministically hashed before validation
+	 * using the configured `hashery` instance. When false, oversized keys throw
+	 * a validation error. To change the algorithm or providers, mutate or
+	 * replace the `hashery` property instead.
 	 * @param {boolean} value
 	 * @default false
 	 */
 	public set hashLargeKey(value: boolean) {
 		this._hashLargeKey = value;
+	}
+
+	/**
+	 * The `Hashery` instance used to hash oversized keys when `hashLargeKey`
+	 * is enabled. Always returns an instance, even when hashing is disabled,
+	 * so callers can pre-configure it (e.g. set `defaultAlgorithmSync` or
+	 * register custom providers) before flipping `hashLargeKey` on.
+	 * @returns {Hashery}
+	 */
+	public get hashery(): Hashery {
+		return this._hashery;
+	}
+
+	/**
+	 * Replace the `Hashery` instance used to hash oversized keys.
+	 * @param {Hashery} value
+	 */
+	public set hashery(value: Hashery) {
+		this._hashery = value;
 	}
 
 	/**
@@ -1378,7 +1414,7 @@ export class Memcache extends Hookified {
 	 */
 	public resolveKey(key: string): string {
 		if (this._hashLargeKey && key.length > this._maxKeySize) {
-			return djb2Hasher.toHashSync(keyEncoder.encode(key));
+			return this._hashery.toHashSync(key);
 		}
 		return key;
 	}
@@ -1666,5 +1702,12 @@ export class Memcache extends Hookified {
 	}
 }
 
-export { AutoDiscovery, BroadcastHash, createNode, MemcacheNode, ModulaHash };
+export {
+	AutoDiscovery,
+	BroadcastHash,
+	createNode,
+	Hashery,
+	MemcacheNode,
+	ModulaHash,
+};
 export default Memcache;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { DJB2 } from "hashery";
 import { Hookified } from "hookified";
 import { AutoDiscovery } from "./auto-discovery.js";
 import { BroadcastHash } from "./broadcast.js";
@@ -48,6 +49,10 @@ export const exponentialRetryBackoff: RetryBackoffFunction = (
 // Pre-compiled regex for key validation (avoid re-compiling per call)
 const KEY_INVALID_CHARS = /[\s\r\n\0]/;
 
+// Shared djb2 hasher and encoder used when hashLargeKey is enabled
+const djb2Hasher = new DJB2();
+const keyEncoder = new TextEncoder();
+
 /**
  * Check if all results match an expected value.
  * Fast-paths single-element arrays to avoid .every() overhead.
@@ -74,6 +79,7 @@ export class Memcache extends Hookified {
 	private _maxKeySize: number;
 	private _maxValueSize: number;
 	private _maxExpiration: number;
+	private _hashLargeKey: boolean;
 
 	constructor(options?: string | MemcacheOptions) {
 		super({ throwOnEmptyListeners: false });
@@ -93,6 +99,7 @@ export class Memcache extends Hookified {
 			this._maxKeySize = 250;
 			this._maxValueSize = 1048576;
 			this._maxExpiration = 2592000;
+			this._hashLargeKey = false;
 			this.addNode(options);
 		} else {
 			// Handle MemcacheOptions object
@@ -130,6 +137,7 @@ export class Memcache extends Hookified {
 						: 2592000,
 				),
 			);
+			this._hashLargeKey = options?.hashLargeKey ?? false;
 			this._autoDiscoverOptions = options?.autoDiscover;
 
 			// Add nodes if provided, otherwise add default node
@@ -234,6 +242,26 @@ export class Memcache extends Hookified {
 			0,
 			Math.floor(Number.isFinite(value) ? value : 0),
 		);
+	}
+
+	/**
+	 * Whether keys exceeding `maxKeySize` are hashed with djb2 instead of throwing.
+	 * @returns {boolean}
+	 * @default false
+	 */
+	public get hashLargeKey(): boolean {
+		return this._hashLargeKey;
+	}
+
+	/**
+	 * Enable or disable djb2 hashing of keys that exceed `maxKeySize`.
+	 * When true, oversized keys are deterministically hashed before validation.
+	 * When false, oversized keys throw a validation error.
+	 * @param {boolean} value
+	 * @default false
+	 */
+	public set hashLargeKey(value: boolean) {
+		this._hashLargeKey = value;
 	}
 
 	/**
@@ -614,12 +642,13 @@ export class Memcache extends Hookified {
 			await this.beforeHook("get", { key });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 
-		const nodes = await this.getNodesByKey(key);
+		const nodes = await this.getNodesByKey(resolvedKey);
 		const commandOptions = {
 			isMultiline: true,
-			requestedKeys: [key],
+			requestedKeys: [resolvedKey],
 		};
 
 		let value: string | undefined;
@@ -627,7 +656,7 @@ export class Memcache extends Hookified {
 		// Primary-first strategy: try nodes sequentially, fall back on failure
 		for (const node of nodes) {
 			try {
-				const result = await node.command(`get ${key}`, commandOptions);
+				const result = await node.command(`get ${resolvedKey}`, commandOptions);
 
 				if (result?.values && result.values.length > 0) {
 					value = result.values[0];
@@ -657,20 +686,28 @@ export class Memcache extends Hookified {
 			await this.beforeHook("gets", { keys });
 		}
 
-		// Validate all keys
-		for (const key of keys) {
-			this.validateKey(key);
+		// Resolve and validate all keys, tracking the mapping so results can be
+		// returned keyed by the original (unresolved) key.
+		const resolvedKeys: string[] = new Array(keys.length);
+		const originalByResolved = new Map<string, string>();
+		for (let i = 0; i < keys.length; i++) {
+			const resolved = this.resolveKey(keys[i]);
+			this.validateKey(resolved);
+			resolvedKeys[i] = resolved;
+			originalByResolved.set(resolved, keys[i]);
 		}
 
-		// Group keys by primary node (first node returned by hash provider)
+		// Group resolved keys by primary node (first node returned by hash provider)
 		const keysByNode = new Map<MemcacheNode, string[]>();
 		const keyToReplicas = new Map<string, MemcacheNode[]>();
 
-		for (const key of keys) {
-			const nodes = this._hash.getNodesByKey(key);
-			/* v8 ignore next 3 -- @preserve */
+		for (const resolvedKey of resolvedKeys) {
+			const nodes = this._hash.getNodesByKey(resolvedKey);
+			/* v8 ignore next 4 -- @preserve */
 			if (nodes.length === 0) {
-				throw new Error(`No node available for key: ${key}`);
+				// biome-ignore lint/style/noNonNullAssertion: resolvedKey is always in originalByResolved
+				const originalKey = originalByResolved.get(resolvedKey)!;
+				throw new Error(`No node available for key: ${originalKey}`);
 			}
 
 			// Route to primary node (first in list)
@@ -679,17 +716,17 @@ export class Memcache extends Hookified {
 				keysByNode.set(primary, []);
 			}
 			// biome-ignore lint/style/noNonNullAssertion: we just set it
-			keysByNode.get(primary)!.push(key);
+			keysByNode.get(primary)!.push(resolvedKey);
 
 			// Track replicas for fallback
 			if (nodes.length > 1) {
-				keyToReplicas.set(key, nodes.slice(1));
+				keyToReplicas.set(resolvedKey, nodes.slice(1));
 			}
 		}
 
 		// Query primary nodes in parallel
 		const map = new Map<string, string>();
-		const missingKeys: string[] = [];
+		const missingResolvedKeys: string[] = [];
 
 		const promises = Array.from(keysByNode.entries()).map(
 			async ([node, nodeKeys]) => {
@@ -712,25 +749,30 @@ export class Memcache extends Hookified {
 
 		const results = await Promise.all(promises);
 
-		// Collect results and track misses for fallback
+		// Collect results (keyed by original) and track misses for fallback
 		for (const { nodeKeys, result } of results) {
 			if (result?.foundKeys && result.values) {
 				for (let i = 0; i < result.foundKeys.length; i++) {
-					map.set(result.foundKeys[i], result.values[i]);
+					const foundResolved = result.foundKeys[i];
+					// biome-ignore lint/style/noNonNullAssertion: foundResolved was in resolvedKeys we sent
+					const originalKey = originalByResolved.get(foundResolved)!;
+					map.set(originalKey, result.values[i]);
 				}
 			}
 
 			// Find keys that failed or weren't found
-			for (const key of nodeKeys) {
-				if (!map.has(key) && keyToReplicas.has(key)) {
-					missingKeys.push(key);
+			for (const resolvedKey of nodeKeys) {
+				// biome-ignore lint/style/noNonNullAssertion: nodeKeys are a subset of resolvedKeys
+				const originalKey = originalByResolved.get(resolvedKey)!;
+				if (!map.has(originalKey) && keyToReplicas.has(resolvedKey)) {
+					missingResolvedKeys.push(resolvedKey);
 				}
 			}
 		}
 
 		// Fallback to replicas for missing keys (primary-first strategy)
-		for (const key of missingKeys) {
-			const replicas = keyToReplicas.get(key);
+		for (const resolvedKey of missingResolvedKeys) {
+			const replicas = keyToReplicas.get(resolvedKey);
 			/* v8 ignore next -- @preserve */
 			if (!replicas) continue;
 
@@ -739,13 +781,15 @@ export class Memcache extends Hookified {
 					/* v8 ignore next -- @preserve */
 					if (!replica.isConnected()) await replica.connect();
 
-					const result = await replica.command(`get ${key}`, {
+					const result = await replica.command(`get ${resolvedKey}`, {
 						isMultiline: true,
-						requestedKeys: [key],
+						requestedKeys: [resolvedKey],
 					});
 
 					if (result?.values && result.values.length > 0) {
-						map.set(key, result.values[0]);
+						// biome-ignore lint/style/noNonNullAssertion: resolvedKey is always in originalByResolved
+						const originalKey = originalByResolved.get(resolvedKey)!;
+						map.set(originalKey, result.values[0]);
 						break;
 					}
 				} catch {
@@ -783,13 +827,14 @@ export class Memcache extends Hookified {
 			await this.beforeHook("cas", { key, value, casToken, exptime, flags });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 		const sanitizedExptime = this.validateExpiration(exptime);
 		const valueStr = String(value);
 		const bytes = this.validateValue(valueStr);
-		const command = `cas ${key} ${flags} ${sanitizedExptime} ${bytes} ${casToken}\r\n${valueStr}`;
+		const command = `cas ${resolvedKey} ${flags} ${sanitizedExptime} ${bytes} ${casToken}\r\n${valueStr}`;
 
-		const nodes = await this.getNodesByKey(key);
+		const nodes = await this.getNodesByKey(resolvedKey);
 		const results = await this.execute(command, nodes);
 		const success = allResultsEqual(results, "STORED");
 
@@ -828,12 +873,13 @@ export class Memcache extends Hookified {
 			await this.beforeHook("set", { key, value, exptime, flags });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 		const sanitizedExptime = this.validateExpiration(exptime);
 		const bytes = this.validateValue(value);
-		const command = `set ${key} ${flags} ${sanitizedExptime} ${bytes}\r\n${value}`;
+		const command = `set ${resolvedKey} ${flags} ${sanitizedExptime} ${bytes}\r\n${value}`;
 
-		const nodes = await this.getNodesByKey(key);
+		const nodes = await this.getNodesByKey(resolvedKey);
 		const results = await this.execute(command, nodes);
 		const success = allResultsEqual(results, "STORED");
 
@@ -864,13 +910,14 @@ export class Memcache extends Hookified {
 			await this.beforeHook("add", { key, value, exptime, flags });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 		const sanitizedExptime = this.validateExpiration(exptime);
 		const valueStr = String(value);
 		const bytes = this.validateValue(valueStr);
-		const command = `add ${key} ${flags} ${sanitizedExptime} ${bytes}\r\n${valueStr}`;
+		const command = `add ${resolvedKey} ${flags} ${sanitizedExptime} ${bytes}\r\n${valueStr}`;
 
-		const nodes = await this.getNodesByKey(key);
+		const nodes = await this.getNodesByKey(resolvedKey);
 		const results = await this.execute(command, nodes);
 		const success = allResultsEqual(results, "STORED");
 
@@ -901,13 +948,14 @@ export class Memcache extends Hookified {
 			await this.beforeHook("replace", { key, value, exptime, flags });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 		const sanitizedExptime = this.validateExpiration(exptime);
 		const valueStr = String(value);
 		const bytes = this.validateValue(valueStr);
-		const command = `replace ${key} ${flags} ${sanitizedExptime} ${bytes}\r\n${valueStr}`;
+		const command = `replace ${resolvedKey} ${flags} ${sanitizedExptime} ${bytes}\r\n${valueStr}`;
 
-		const nodes = await this.getNodesByKey(key);
+		const nodes = await this.getNodesByKey(resolvedKey);
 		const results = await this.execute(command, nodes);
 		const success = allResultsEqual(results, "STORED");
 
@@ -931,12 +979,13 @@ export class Memcache extends Hookified {
 			await this.beforeHook("append", { key, value });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 		const valueStr = String(value);
 		const bytes = this.validateValue(valueStr);
-		const command = `append ${key} 0 0 ${bytes}\r\n${valueStr}`;
+		const command = `append ${resolvedKey} 0 0 ${bytes}\r\n${valueStr}`;
 
-		const nodes = await this.getNodesByKey(key);
+		const nodes = await this.getNodesByKey(resolvedKey);
 		const results = await this.execute(command, nodes);
 		const success = allResultsEqual(results, "STORED");
 
@@ -960,12 +1009,13 @@ export class Memcache extends Hookified {
 			await this.beforeHook("prepend", { key, value });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 		const valueStr = String(value);
 		const bytes = this.validateValue(valueStr);
-		const command = `prepend ${key} 0 0 ${bytes}\r\n${valueStr}`;
+		const command = `prepend ${resolvedKey} 0 0 ${bytes}\r\n${valueStr}`;
 
-		const nodes = await this.getNodesByKey(key);
+		const nodes = await this.getNodesByKey(resolvedKey);
 		const results = await this.execute(command, nodes);
 		const success = allResultsEqual(results, "STORED");
 
@@ -988,10 +1038,11 @@ export class Memcache extends Hookified {
 			await this.beforeHook("delete", { key });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 
-		const nodes = await this.getNodesByKey(key);
-		const results = await this.execute(`delete ${key}`, nodes);
+		const nodes = await this.getNodesByKey(resolvedKey);
+		const results = await this.execute(`delete ${resolvedKey}`, nodes);
 		const success = allResultsEqual(results, "DELETED");
 
 		if (this._hasHooks) {
@@ -1017,10 +1068,11 @@ export class Memcache extends Hookified {
 			await this.beforeHook("incr", { key, value });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 
-		const nodes = await this.getNodesByKey(key);
-		const results = await this.execute(`incr ${key} ${value}`, nodes);
+		const nodes = await this.getNodesByKey(resolvedKey);
+		const results = await this.execute(`incr ${resolvedKey} ${value}`, nodes);
 		const newValue = results.find((v) => typeof v === "number") as
 			| number
 			| undefined;
@@ -1048,10 +1100,11 @@ export class Memcache extends Hookified {
 			await this.beforeHook("decr", { key, value });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 
-		const nodes = await this.getNodesByKey(key);
-		const results = await this.execute(`decr ${key} ${value}`, nodes);
+		const nodes = await this.getNodesByKey(resolvedKey);
+		const results = await this.execute(`decr ${resolvedKey} ${value}`, nodes);
 		const newValue = results.find((v) => typeof v === "number") as
 			| number
 			| undefined;
@@ -1076,12 +1129,13 @@ export class Memcache extends Hookified {
 			await this.beforeHook("touch", { key, exptime });
 		}
 
-		this.validateKey(key);
+		const resolvedKey = this.resolveKey(key);
+		this.validateKey(resolvedKey);
 		const sanitizedExptime = this.validateExpiration(exptime);
 
-		const nodes = await this.getNodesByKey(key);
+		const nodes = await this.getNodesByKey(resolvedKey);
 		const results = await this.execute(
-			`touch ${key} ${sanitizedExptime}`,
+			`touch ${resolvedKey} ${sanitizedExptime}`,
 			nodes,
 		);
 		const success = allResultsEqual(results, "TOUCHED");
@@ -1296,6 +1350,28 @@ export class Memcache extends Hookified {
 		});
 
 		return Promise.all(promises);
+	}
+
+	/**
+	 * Resolves a key for transmission to the memcache server. When `hashLargeKey`
+	 * is true and the key length exceeds `maxKeySize`, the key is replaced with a
+	 * djb2 hex digest (via the `hashery` library) so it fits within the limit.
+	 * Otherwise the original key is returned unchanged.
+	 * @param {string} key - The original cache key
+	 * @returns {string} The key to send to memcache (possibly hashed)
+	 *
+	 * @example
+	 * ```typescript
+	 * const client = new Memcache({ hashLargeKey: true });
+	 * client.resolveKey("a".repeat(300)); // returns 8-char djb2 hex digest
+	 * client.resolveKey("short-key");      // returns "short-key"
+	 * ```
+	 */
+	public resolveKey(key: string): string {
+		if (this._hashLargeKey && key.length > this._maxKeySize) {
+			return djb2Hasher.toHashSync(keyEncoder.encode(key));
+		}
+		return key;
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -686,28 +686,32 @@ export class Memcache extends Hookified {
 			await this.beforeHook("gets", { keys });
 		}
 
-		// Resolve and validate all keys, tracking the mapping so results can be
-		// returned keyed by the original (unresolved) key.
-		const resolvedKeys: string[] = new Array(keys.length);
-		const originalByResolved = new Map<string, string>();
-		for (let i = 0; i < keys.length; i++) {
-			const resolved = this.resolveKey(keys[i]);
+		// Resolve and validate all keys. A single resolved key can map back to
+		// multiple original input keys when distinct inputs collide on djb2 (or
+		// when the caller passes duplicates), so track originals as an array.
+		const originalsByResolved = new Map<string, string[]>();
+		for (const inputKey of keys) {
+			const resolved = this.resolveKey(inputKey);
 			this.validateKey(resolved);
-			resolvedKeys[i] = resolved;
-			originalByResolved.set(resolved, keys[i]);
+			let originals = originalsByResolved.get(resolved);
+			if (!originals) {
+				originals = [];
+				originalsByResolved.set(resolved, originals);
+			}
+			originals.push(inputKey);
 		}
 
-		// Group resolved keys by primary node (first node returned by hash provider)
+		// Group unique resolved keys by primary node (first node returned by hash provider)
 		const keysByNode = new Map<MemcacheNode, string[]>();
 		const keyToReplicas = new Map<string, MemcacheNode[]>();
 
-		for (const resolvedKey of resolvedKeys) {
+		for (const resolvedKey of originalsByResolved.keys()) {
 			const nodes = this._hash.getNodesByKey(resolvedKey);
 			/* v8 ignore next 4 -- @preserve */
 			if (nodes.length === 0) {
-				// biome-ignore lint/style/noNonNullAssertion: resolvedKey is always in originalByResolved
-				const originalKey = originalByResolved.get(resolvedKey)!;
-				throw new Error(`No node available for key: ${originalKey}`);
+				// biome-ignore lint/style/noNonNullAssertion: resolvedKey is always in originalsByResolved
+				const firstOriginal = originalsByResolved.get(resolvedKey)![0];
+				throw new Error(`No node available for key: ${firstOriginal}`);
 			}
 
 			// Route to primary node (first in list)
@@ -749,22 +753,25 @@ export class Memcache extends Hookified {
 
 		const results = await Promise.all(promises);
 
-		// Collect results (keyed by original) and track misses for fallback
+		// Collect results (keyed by every original input key) and track misses for fallback
 		for (const { nodeKeys, result } of results) {
 			if (result?.foundKeys && result.values) {
 				for (let i = 0; i < result.foundKeys.length; i++) {
 					const foundResolved = result.foundKeys[i];
 					// biome-ignore lint/style/noNonNullAssertion: foundResolved was in resolvedKeys we sent
-					const originalKey = originalByResolved.get(foundResolved)!;
-					map.set(originalKey, result.values[i]);
+					const originals = originalsByResolved.get(foundResolved)!;
+					for (const original of originals) {
+						map.set(original, result.values[i]);
+					}
 				}
 			}
 
-			// Find keys that failed or weren't found
+			// Find keys that failed or weren't found. All originals for a given
+			// resolved key are set together, so checking the first is sufficient.
 			for (const resolvedKey of nodeKeys) {
-				// biome-ignore lint/style/noNonNullAssertion: nodeKeys are a subset of resolvedKeys
-				const originalKey = originalByResolved.get(resolvedKey)!;
-				if (!map.has(originalKey) && keyToReplicas.has(resolvedKey)) {
+				// biome-ignore lint/style/noNonNullAssertion: nodeKeys are unique resolved keys
+				const firstOriginal = originalsByResolved.get(resolvedKey)![0];
+				if (!map.has(firstOriginal) && keyToReplicas.has(resolvedKey)) {
 					missingResolvedKeys.push(resolvedKey);
 				}
 			}
@@ -787,9 +794,11 @@ export class Memcache extends Hookified {
 					});
 
 					if (result?.values && result.values.length > 0) {
-						// biome-ignore lint/style/noNonNullAssertion: resolvedKey is always in originalByResolved
-						const originalKey = originalByResolved.get(resolvedKey)!;
-						map.set(originalKey, result.values[0]);
+						// biome-ignore lint/style/noNonNullAssertion: resolvedKey is always in originalsByResolved
+						const originals = originalsByResolved.get(resolvedKey)!;
+						for (const original of originals) {
+							map.set(original, result.values[0]);
+						}
 						break;
 					}
 				} catch {

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,18 @@ export interface MemcacheOptions {
 	maxKeySize?: number;
 
 	/**
+	 * When true, keys whose length exceeds `maxKeySize` are deterministically
+	 * hashed with djb2 (via the `hashery` library) before being sent to the
+	 * server, so long keys do not throw a validation error. When false (default),
+	 * keys exceeding `maxKeySize` throw a validation error.
+	 *
+	 * Note: hashing is one-way and can collide. Two distinct long keys could map
+	 * to the same hashed key.
+	 * @default false
+	 */
+	hashLargeKey?: boolean;
+
+	/**
 	 * The maximum allowed value size in bytes. Memcached default max is 1048576 (1 MiB).
 	 * @default 1048576
 	 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { Hashery } from "hashery";
 import type { CommandOptions, MemcacheNode } from "./node.js";
 
 /**
@@ -133,16 +134,19 @@ export interface MemcacheOptions {
 	maxKeySize?: number;
 
 	/**
-	 * When true, keys whose length exceeds `maxKeySize` are deterministically
-	 * hashed with djb2 (via the `hashery` library) before being sent to the
-	 * server, so long keys do not throw a validation error. When false (default),
-	 * keys exceeding `maxKeySize` throw a validation error.
+	 * Controls hashing of keys whose length exceeds `maxKeySize`.
+	 * - `false` (default): oversized keys throw a validation error.
+	 * - `true`: oversized keys are deterministically hashed with a default
+	 *   `Hashery` instance (djb2 sync) before being sent to the server.
+	 * - a `Hashery` instance: oversized keys are hashed with that instance,
+	 *   so callers can pick `fnv1` / `murmur` / `crc32`, plug in custom
+	 *   providers, enable caching, etc.
 	 *
-	 * Note: hashing is one-way and can collide. Two distinct long keys could map
-	 * to the same hashed key.
+	 * Note: hashing is one-way and can collide. Two distinct long keys could
+	 * map to the same hashed key.
 	 * @default false
 	 */
-	hashLargeKey?: boolean;
+	hashLargeKey?: boolean | Hashery;
 
 	/**
 	 * The maximum allowed value size in bytes. Memcached default max is 1048576 (1 MiB).

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,6 +4,7 @@ import Memcache, {
 	createNode,
 	defaultRetryBackoff,
 	exponentialRetryBackoff,
+	Hashery,
 	MemcacheEvents,
 	ModulaHash,
 	type RetryBackoffFunction,
@@ -941,6 +942,57 @@ describe("Memcache", () => {
 			const longKey = "a".repeat(17);
 			expect(customClient.resolveKey(shortKey)).toBe(shortKey);
 			expect(customClient.resolveKey(longKey)).not.toBe(longKey);
+		});
+
+		describe("Hashery integration", () => {
+			it("exposes a default Hashery instance even when hashLargeKey is false", () => {
+				expect(client.hashery).toBeInstanceOf(Hashery);
+				expect(client.hashLargeKey).toBe(false);
+			});
+
+			it("exposes a default Hashery instance for the string-arg constructor", () => {
+				const stringClient = new Memcache("localhost:11211");
+				expect(stringClient.hashery).toBeInstanceOf(Hashery);
+			});
+
+			it("accepts true and creates a default Hashery", () => {
+				const c = new Memcache({ hashLargeKey: true });
+				expect(c.hashLargeKey).toBe(true);
+				expect(c.hashery).toBeInstanceOf(Hashery);
+			});
+
+			it("accepts a custom Hashery instance and enables hashing", () => {
+				const custom = new Hashery();
+				const c = new Memcache({ hashLargeKey: custom });
+				expect(c.hashLargeKey).toBe(true);
+				expect(c.hashery).toBe(custom);
+			});
+
+			it("respects defaultAlgorithmSync on the supplied Hashery", () => {
+				const longKey = "a".repeat(300);
+				const djb2Client = new Memcache({ hashLargeKey: true });
+				const fnv1Hashery = new Hashery({ defaultAlgorithmSync: "fnv1" });
+				const fnv1Client = new Memcache({ hashLargeKey: fnv1Hashery });
+				expect(djb2Client.resolveKey(longKey)).not.toBe(
+					fnv1Client.resolveKey(longKey),
+				);
+			});
+
+			it("uses the algorithm currently configured on the Hashery (mutable)", () => {
+				const longKey = "a".repeat(300);
+				const c = new Memcache({ hashLargeKey: true });
+				const djb2Hash = c.resolveKey(longKey);
+				c.hashery.defaultAlgorithmSync = "fnv1";
+				const fnv1Hash = c.resolveKey(longKey);
+				expect(djb2Hash).not.toBe(fnv1Hash);
+			});
+
+			it("allows swapping the Hashery via the setter", () => {
+				const c = new Memcache({ hashLargeKey: true });
+				const replacement = new Hashery({ defaultAlgorithmSync: "murmur" });
+				c.hashery = replacement;
+				expect(c.hashery).toBe(replacement);
+			});
 		});
 
 		it("gets should return values for all original keys when resolved keys collide", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -840,6 +840,110 @@ describe("Memcache", () => {
 		});
 	});
 
+	describe("hashLargeKey", () => {
+		it("should default hashLargeKey to false", () => {
+			expect(client.hashLargeKey).toBe(false);
+		});
+
+		it("should default hashLargeKey to false for string-param constructor", () => {
+			const stringClient = new Memcache("localhost:11211");
+			expect(stringClient.hashLargeKey).toBe(false);
+		});
+
+		it("should honor hashLargeKey passed via constructor options", () => {
+			const customClient = new Memcache({ hashLargeKey: true });
+			expect(customClient.hashLargeKey).toBe(true);
+		});
+
+		it("should honor hashLargeKey updated via setter", () => {
+			client.hashLargeKey = true;
+			expect(client.hashLargeKey).toBe(true);
+			client.hashLargeKey = false;
+			expect(client.hashLargeKey).toBe(false);
+		});
+
+		it("should return the original key from resolveKey when hashLargeKey is false", () => {
+			const longKey = "a".repeat(300);
+			expect(client.hashLargeKey).toBe(false);
+			expect(client.resolveKey(longKey)).toBe(longKey);
+		});
+
+		it("should return the original key from resolveKey when key length is within maxKeySize", () => {
+			const customClient = new Memcache({ hashLargeKey: true });
+			const shortKey = "short-key";
+			expect(customClient.resolveKey(shortKey)).toBe(shortKey);
+		});
+
+		it("should return original key when key length exactly equals maxKeySize", () => {
+			const customClient = new Memcache({ hashLargeKey: true });
+			const exactKey = "a".repeat(customClient.maxKeySize);
+			expect(customClient.resolveKey(exactKey)).toBe(exactKey);
+		});
+
+		it("should return djb2 hashed key when hashLargeKey is true and key exceeds maxKeySize", () => {
+			const customClient = new Memcache({ hashLargeKey: true });
+			const longKey = "a".repeat(300);
+			const hashed = customClient.resolveKey(longKey);
+			expect(hashed).not.toBe(longKey);
+			expect(hashed.length).toBeLessThanOrEqual(customClient.maxKeySize);
+			// djb2 produces 8-character hex strings
+			expect(hashed).toMatch(/^[0-9a-f]{1,8}$/);
+		});
+
+		it("should produce deterministic hashes (same key always produces same hash)", () => {
+			const customClient = new Memcache({ hashLargeKey: true });
+			const longKey = "a".repeat(300);
+			const hash1 = customClient.resolveKey(longKey);
+			const hash2 = customClient.resolveKey(longKey);
+			expect(hash1).toBe(hash2);
+		});
+
+		it("should produce different hashes for different keys", () => {
+			const customClient = new Memcache({ hashLargeKey: true });
+			const key1 = "a".repeat(300);
+			const key2 = "b".repeat(300);
+			expect(customClient.resolveKey(key1)).not.toBe(
+				customClient.resolveKey(key2),
+			);
+		});
+
+		it("should not throw on get when key exceeds maxKeySize and hashLargeKey is true", async () => {
+			const customClient = new Memcache({
+				hashLargeKey: true,
+				timeout: 100,
+			});
+			const longKey = "a".repeat(300);
+			// validateKey should not throw because the key is hashed before validation
+			// Actual network call may fail (no server), but we only verify no key-length error
+			try {
+				await customClient.get(longKey);
+			} catch (err) {
+				expect((err as Error).message).not.toContain(
+					"Key length cannot exceed",
+				);
+			}
+			await customClient.disconnect();
+		});
+
+		it("should still throw on get when key exceeds maxKeySize and hashLargeKey is false", async () => {
+			const longKey = "a".repeat(300);
+			await expect(client.get(longKey)).rejects.toThrow(
+				"Key length cannot exceed 250 characters",
+			);
+		});
+
+		it("should respect a custom maxKeySize when deciding to hash", () => {
+			const customClient = new Memcache({
+				hashLargeKey: true,
+				maxKeySize: 16,
+			});
+			const shortKey = "a".repeat(16);
+			const longKey = "a".repeat(17);
+			expect(customClient.resolveKey(shortKey)).toBe(shortKey);
+			expect(customClient.resolveKey(longKey)).not.toBe(longKey);
+		});
+	});
+
 	describe("Value Validation", () => {
 		it("should default maxValueSize to 1048576", () => {
 			expect(client.maxValueSize).toBe(1048576);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -942,6 +942,36 @@ describe("Memcache", () => {
 			expect(customClient.resolveKey(shortKey)).toBe(shortKey);
 			expect(customClient.resolveKey(longKey)).not.toBe(longKey);
 		});
+
+		it("gets should return values for all original keys when resolved keys collide", async () => {
+			// djb2 collisions are rare but possible; force one by overriding
+			// resolveKey so two distinct long inputs map to the same wire key.
+			const customClient = new Memcache({ hashLargeKey: true });
+			await customClient.connect();
+
+			const longKeyA = `${generateKey("collide-a")}-${"x".repeat(260)}`;
+			const longKeyB = `${generateKey("collide-b")}-${"y".repeat(260)}`;
+			const sharedHash = generateKey("shared");
+
+			const originalResolveKey = customClient.resolveKey.bind(customClient);
+			customClient.resolveKey = (key: string) => {
+				if (key === longKeyA || key === longKeyB) return sharedHash;
+				return originalResolveKey(key);
+			};
+
+			try {
+				const value = generateValue();
+				await customClient.set(longKeyA, value);
+
+				const results = await customClient.gets([longKeyA, longKeyB]);
+				expect(results.get(longKeyA)).toBe(value);
+				expect(results.get(longKeyB)).toBe(value);
+				expect(results.size).toBe(2);
+			} finally {
+				await customClient.delete(longKeyA);
+				await customClient.disconnect();
+			}
+		});
 	});
 
 	describe("Value Validation", () => {


### PR DESCRIPTION
## Summary

- Adds `hashLargeKey?: boolean` (default `false`) to `MemcacheOptions`. When enabled, keys whose length exceeds `maxKeySize` are deterministically hashed with djb2 (via the [`hashery`](https://github.com/jaredwray/hashery) library) before being sent to the server, instead of throwing a validation error.
- Adds a `hashLargeKey` getter/setter and a public `resolveKey(key)` helper that returns the on-wire key (hashed or unchanged).
- Wires `resolveKey` into every key-taking command (`get`, `gets`, `set`, `add`, `replace`, `append`, `prepend`, `delete`, `incr`, `decr`, `touch`, `cas`). Hooks continue to see the original (unresolved) key.
- `gets()` returns its result map keyed by the original caller keys, so callers don't need to know about the hash transformation.

## Why

Memcache's protocol caps keys at 250 characters. Today this client throws on anything longer. With `hashLargeKey: true`, callers can use arbitrarily long keys without pre-hashing themselves; the same input always maps to the same short djb2 hex digest. The behavior is opt-in to avoid changing semantics for existing users.

## Notes for reviewers

- djb2 is a non-cryptographic hash; distinct long keys can collide. The README and JSDoc call this out.
- Default behavior (`hashLargeKey: false`) is unchanged — long keys still throw.
- `resolveKey` is exposed on the public API (parallel to `validateKey`) so callers can inspect what key will actually be sent.
- 13 new tests cover defaults, constructor option, setter, custom `maxKeySize`, exact-length boundary, deterministic hashing, distinct-input distinctness, and the long-key flow with the option enabled vs. disabled.
- README updated in three places (Options list, Properties section, Validation section).

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` succeeds — 604 tests pass; 100% statements/lines and 100% branches in `index.ts`
- [x] Lint clean (`biome check --error-on-warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)