### PR TITLE
root - chore: adopt pnpm 11 with corepack

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -15,12 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v4
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24
+        cache: 'pnpm'
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
     - name: Build
       run: pnpm build
 
@@ -29,12 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v4
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24
+        cache: 'pnpm'
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
     - name: Test Services
       run: pnpm test:services:start
     - name: Build
@@ -47,12 +51,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v4
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24
+        cache: 'pnpm'
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
     - name: Test Services
       run: pnpm test:services:start
     - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,12 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v4
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24
+        cache: 'pnpm'
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
     - name: Build
       run: pnpm build
 
@@ -27,12 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v4
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24
+        cache: 'pnpm'
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
     - name: Test Services
       run: pnpm test:services:start
     - name: Build
@@ -45,12 +49,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v4
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24
+        cache: 'pnpm'
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
     - name: Build
       run: pnpm build
     - name: Publish

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,15 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['20', '22', '24']
+        node-version: ['22', '24', '26']
     steps:
     - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
     - name: Build
       run: pnpm build
 
@@ -32,15 +34,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['20', '22', '24']
+        node-version: ['22', '24', '26']
     steps:
     - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
     - name: Test Services
       run: pnpm test:services:start
     - name: Build

--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
     "url": "https://github.com/jaredwray/memcache/issues"
   },
   "homepage": "https://github.com/jaredwray/memcache#readme",
+  "engines": {
+    "node": ">=22",
+    "pnpm": ">=11"
+  },
+  "packageManager": "pnpm@11.5.2",
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",
     "@faker-js/faker": "^10.4.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
 allowBuilds:
   esbuild: true
 minimumReleaseAge: 2880
-onlyBuiltDependencies:
-  - esbuild


### PR DESCRIPTION
## Summary
Adopt **pnpm 11** (via corepack), modernize the CI pnpm setup with `pnpm/action-setup`, and move the test matrix to **Node 22/24/26**.

## Changes
**package.json**
- Add `"packageManager": "pnpm@11.5.2"` (used by corepack and `pnpm/action-setup`)
- Add `engines`: `node >=22`, `pnpm >=11`

**pnpm-workspace.yaml — pnpm 11 migration**
- Remove `onlyBuiltDependencies` (removed in pnpm 11). The existing `allowBuilds: { esbuild: true }` is the v11 build-approval form and already covers esbuild. `minimumReleaseAge: 2880` retained (still valid; just an explicit override of v11's new 1-day default).

**GitHub Actions** (`tests`, `code-coverage`, `release`)
- Replace `npm install pnpm -g && pnpm install` with `pnpm/action-setup@v4` + `actions/setup-node@v6` (`cache: 'pnpm'`) and a plain `pnpm install`. `pnpm/action-setup` picks up the pinned version from `packageManager`.
- `tests` matrix: `['20','22','24']` → `['22','24','26']`. (`codeql.yaml` installs no deps, so it's unchanged.)

## Why Node 22+
pnpm 11 requires Node 22+ (drops 18–21), so the matrix and `engines.node` move to ≥22. This also lands the Node-20 drop discussed on #89.

## Verification (locally, pnpm 11.5.2 via corepack)
- [x] `pnpm install` — migrated workspace config accepted; **esbuild build script still runs** via `allowBuilds`; lockfile unchanged (v9.0)
- [x] `pnpm build` passes
- [x] `pnpm test` passes (612 tests, 100% statement/line coverage)
- [x] All workflow YAML parses

## Note
This formally drops Node 20 support via `engines.node: >=22` (consistent with hookified v3 / docula v2 / pnpm 11). Easy to tweak the exact range if you'd prefer e.g. `>=22.18`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzDsVCGFyxWNZQirNWZbgg)_