### PR TITLE
release: v1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memcache",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Nodejs Memcache Client",
   "main": "./dist/index.cjs",
   "type": "module",


### PR DESCRIPTION
## Release summary
Maintenance release: dependency, build, and CI upgrades. Minimum supported Node is now 22.

## Packages
| Package | Current | New | Bump | Rationale | Commits |
|---|---|---|---|---|---|
| `memcache` | `1.7.0` | `1.8.0` | **minor** | 6 dependency/tooling upgrades; runtime baseline raised to Node ≥22 | 6 |

_Single-package repo — table included for completeness._

## memcache@1.8.0 — 2026-06-08

Maintenance release: dependency, build, and CI upgrades. Minimum supported Node is now 22.

### Internal
- raise minimum Node to 22 and adopt pnpm 11 via corepack; CI matrix now Node 22/24/26 (c3f68e2, #90)
- upgrade hookified runtime dependency to v3 — no API changes (f660f54, #89)
- upgrade all GitHub Actions to their latest majors (67d8b27, #88)
- upgrade docula docs tooling to v2 (f6e881b, #87)
- upgrade TypeScript build tooling — tsx, tsdown (109cf2d, #86)
- upgrade code quality dependencies — biome, vitest, tinybench (7644273, #85)

### Contributors
- @jaredwray (6)

### Full List of Changes
- root - chore: upgrade code quality dependencies by @jaredwray in #85
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #86
- root - chore: upgrade docula (breaking) by @jaredwray in #87
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #88
- root - chore: upgrade hookified (breaking) by @jaredwray in #89
- root - chore: adopt pnpm 11 with corepack by @jaredwray in #90

**Full diff:** https://github.com/jaredwray/memcache/compare/v1.7.0...v1.8.0

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds (ESM + CJS + type definitions)
- [x] `biome check --error-on-warnings` passes (the lint gate of `pnpm test`)
- [ ] Full `pnpm test` integration suite — **not run locally**: the Docker daemon (memcached service) isn't available in the release sandbox. This is a version-only change; `src/` and `test/` are unchanged from `main` (green CI). This PR's own CI runs the full suite with services.
- [x] No uncommitted changes outside the version bump (this repo keeps no `CHANGELOG.md`)

## Post-merge
Merge, then create a GitHub Release at tag `v1.8.0` — the `release.yaml` workflow (`on: release: [released]`) publishes to npm.

https://claude.ai/code/session_01FqSgDDSaeQFa4YbavRubVb

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqSgDDSaeQFa4YbavRubVb)_