### PR TITLE
ci: migrate release workflow to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 24
-        cache: 'pnpm'
     - name: Install Dependencies
       run: pnpm install
     - name: Build
@@ -34,7 +33,6 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 24
-        cache: 'pnpm'
     - name: Install Dependencies
       run: pnpm install
     - name: Test Services
@@ -47,6 +45,9 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - uses: actions/checkout@v6
     - uses: pnpm/action-setup@v4
@@ -54,14 +55,9 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 24
-        cache: 'pnpm'
     - name: Install Dependencies
       run: pnpm install
     - name: Build
       run: pnpm build
     - name: Publish
-      run: |
-        npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-        npm publish --ignore-scripts
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: pnpm publish --provenance --no-git-checks


### PR DESCRIPTION
## Summary

Migrates `.github/workflows/release.yaml` to publish to npm via **OIDC trusted publishing**, removing the long-lived `NPM_TOKEN` secret.

## Changes

- **OIDC + provenance**: The `publish` job now grants `id-token: write` and publishes with `pnpm publish --provenance`. With trusted publishing, npm verifies the workflow's OIDC token and generates provenance attestations automatically — no token required.
- **Remove npm token**: Dropped `npm config set //registry.npmjs.org/:_authToken` and the `NPM_TOKEN` secret/env. The `npm publish` command is gone.
- **pnpm only**: Publishing now uses `pnpm publish` instead of `npm publish`, so the workflow uses pnpm exclusively.
- **No pnpm cache**: Removed `cache: 'pnpm'` from every `actions/setup-node` step.
- **pnpm setup action**: Continues to use `pnpm/action-setup@v4`.

## Notes / prerequisites

- Requires a **trusted publisher** to be configured for the `memcache` package on npmjs.com, pointing at this repo + the `release` workflow. (One initial token-based publish is needed before OIDC can be configured if the package doesn't already exist.)
- OIDC trusted publishing needs npm CLI ≥ 11.5.1. This repo pins `pnpm@11.5.2` via `packageManager`, which includes the fix for OIDC publishing on pnpm 11 ([pnpm#11513](https://github.com/pnpm/pnpm/issues/11513)).
- `--no-git-checks` is passed since the release runs on a tagged/detached checkout.

## References

- [npm trusted publishing with OIDC is GA](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)
- [Trusted publishing for npm packages](https://docs.npmjs.com/trusted-publishers/)
- [Generating provenance statements](https://docs.npmjs.com/generating-provenance-statements/)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LN7jpHp6gG814dBirdr9Qy)_