### PR TITLE
ci: consolidate build and test into a single job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,26 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ['22', '24', '26']
-    steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'pnpm'
-    - name: Install Dependencies
-      run: pnpm install
-    - name: Build
-      run: pnpm build
-
   test:
-    needs: build
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Consolidates the `tests` workflow so build and test run within a single job instead of two separate jobs.

Previously there were two jobs:
- `build` — installed deps and ran `pnpm build`
- `test` — `needs: build`, then re-installed deps, started test services, ran `pnpm build` **again**, and ran `pnpm test:ci`

The `build` job was redundant since the `test` job already built the project. This change removes the standalone `build` job and runs build → test sequentially in one job.

## Changes

- Remove the separate `build` job and its `needs: build` dependency
- Keep a single `test` job that installs dependencies, starts test services, builds, then runs `pnpm test:ci`

This removes a redundant build, avoids a second matrix of runners spinning up, and keeps everything in one job as requested.

https://claude.ai/code/session_016CT7uWVd5Xsoz2EC5Gdc7x

---
_Generated by [Claude Code](https://claude.ai/code/session_016CT7uWVd5Xsoz2EC5Gdc7x)_