### PR TITLE
root - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -14,8 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
@@ -30,8 +30,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
@@ -50,8 +50,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
@@ -27,8 +27,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
@@ -49,8 +49,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         node-version: ['22', '24', '26']
     steps:
-    - uses: actions/checkout@v6
-    - uses: pnpm/action-setup@v4
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
## Summary
Upgrade GitHub Actions to their latest major versions.

## Versions
- `actions/checkout` `@v6` → `@v7`
- `pnpm/action-setup` `@v4` → `@v6`

`actions/setup-node@v6`, `github/codeql-action@v4`, and `codecov/codecov-action@v7` are already on their latest major — the floating `@vX` pin already tracks minor/patch, so no change needed. Pin style (`@vX`) preserved.

## Tests
- [x] Workflow YAML validated (all four parse)
- CI on this PR runs with the upgraded action versions across every workflow

## Breaking notes
- `actions/checkout@v7`: ESM rewrite; now blocks fork-PR checkout on `pull_request_target`/`workflow_run`. These workflows trigger on `pull_request`/`push`/`release` on GitHub-hosted runners, so they're unaffected.
- `pnpm/action-setup@v6`: adds pnpm v11 support (this repo runs `pnpm@11.5.2`); still resolves the pnpm version from the `packageManager` field, so no `with:` block change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqhnMb2Khr8eYnWmYbAmtd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqhnMb2Khr8eYnWmYbAmtd)_