### PR TITLE
root - chore: raise Node engine floor to >=22.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/jaredwray/memcache#readme",
   "engines": {
-    "node": ">=22",
+    "node": ">=22.19.0",
     "pnpm": ">=11"
   },
   "packageManager": "pnpm@11.5.2",


### PR DESCRIPTION
## Summary
Align the declared Node engine floor with the toolchain after the `docula` 2.1.0 upgrade (#97), as flagged by the Codex reviewer.

## Change
- `engines.node` `>=22` → `>=22.19.0`

`docula@2.1.0` (and its transitive `undici`) declare `node: "^22.19.0 || >=24"`. `.nvmrc` (24) and CI (Node 22/24/26, where 22.x resolves to ≥22.19) already satisfy this — this change just makes the declared range consistent with what the toolchain actually needs.

## Tests
- [x] `pnpm test:ci` passes (612 tests, 100% statement/line coverage)
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqhnMb2Khr8eYnWmYbAmtd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqhnMb2Khr8eYnWmYbAmtd)_