### PR TITLE
root - chore: upgrade hookified

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "hashery": "^2.0.0",
-    "hookified": "^3.0.0"
+    "hookified": "^3.0.1"
   },
   "files": [
     "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       hookified:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.2
@@ -1596,6 +1596,10 @@ packages:
 
   hookified@3.0.0:
     resolution: {integrity: sha512-x+jzDjd9CWxdgl6u/K4pjnvw7PZx6ZSpiPGAV43uXlJiJy7r2jIEUxxU1Cv7+rwy1GK5Qt5S+Jp7n81DpcUvTA==}
+    engines: {node: '>=22.18.0'}
+
+  hookified@3.0.1:
+    resolution: {integrity: sha512-mtpUIV7U9reosQ16+OHWBd0Ca07fs1ryChQjBPuUMZnrRdLTCW+kEfkTcFudkaevp3gVe5H9FxDCBxYIdO+QQA==}
     engines: {node: '>=22.18.0'}
 
   html-dom-parser@8.0.0:
@@ -3968,6 +3972,8 @@ snapshots:
   hookified@2.2.0: {}
 
   hookified@3.0.0: {}
+
+  hookified@3.0.1: {}
 
   html-dom-parser@8.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
Upgrade the `hookified` runtime dependency (patch).

## Versions
- `hookified` `3.0.0` → `3.0.1`

## Tests
- [x] `pnpm test:ci` passes (612 tests, 100% statement/line coverage)
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqhnMb2Khr8eYnWmYbAmtd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqhnMb2Khr8eYnWmYbAmtd)_