### PR TITLE
root - chore: upgrade hashery (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
-    "hashery": "^2.0.0",
+    "hashery": "^3.0.0",
     "hookified": "^3.0.1"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       hashery:
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^3.0.0
+        version: 3.0.0
       hookified:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1593,10 +1593,6 @@ packages:
 
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
-
-  hookified@3.0.0:
-    resolution: {integrity: sha512-x+jzDjd9CWxdgl6u/K4pjnvw7PZx6ZSpiPGAV43uXlJiJy7r2jIEUxxU1Cv7+rwy1GK5Qt5S+Jp7n81DpcUvTA==}
-    engines: {node: '>=22.18.0'}
 
   hookified@3.0.1:
     resolution: {integrity: sha512-mtpUIV7U9reosQ16+OHWBd0Ca07fs1ryChQjBPuUMZnrRdLTCW+kEfkTcFudkaevp3gVe5H9FxDCBxYIdO+QQA==}
@@ -3844,7 +3840,7 @@ snapshots:
 
   hashery@3.0.0:
     dependencies:
-      hookified: 3.0.0
+      hookified: 3.0.1
 
   hashring@3.2.0:
     dependencies:
@@ -3970,8 +3966,6 @@ snapshots:
   hookified@1.15.1: {}
 
   hookified@2.2.0: {}
-
-  hookified@3.0.0: {}
 
   hookified@3.0.1: {}
 


### PR DESCRIPTION
## Summary
Upgrade the `hashery` runtime dependency (major).

## Versions
- `hashery` `2.0.0` → `3.0.0`

## Tests
- [x] `pnpm test:ci` passes (612 tests, 100% statement/line coverage)
- [x] `pnpm build` passes

## Breaking notes
`hashery` 3.0.0 is a **toolchain-only** major (pnpm 11, build/CI modernization) — its public API is unchanged: `Hashery` still extends `Hookified`, and `new Hashery()`, `instanceof Hashery`, and `toHashSync()` behave identically. The only breaking aspect is a raised minimum Node of **22.18**, already satisfied by `engines.node >=22.19.0` (#98). **No source changes were required**, and the large-key tests confirm the djb2 digest output is byte-identical (no cache-key drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqhnMb2Khr8eYnWmYbAmtd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqhnMb2Khr8eYnWmYbAmtd)_