### PR TITLE
root - chore: pin memcached test-service image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   memcached1:
-    image: memcached:latest
+    image: memcached:1.6.44
     container_name: memcached-server-1
     ports:
       - "11211:11211"
@@ -8,7 +8,7 @@ services:
     restart: unless-stopped
 
   memcached2:
-    image: memcached:latest
+    image: memcached:1.6.44
     container_name: memcached-server-2
     ports:
       - "11212:11211"
@@ -16,7 +16,7 @@ services:
     restart: unless-stopped
 
   memcached3:
-    image: memcached:latest
+    image: memcached:1.6.44
     container_name: memcached-server-3
     ports:
       - "11213:11211"

--- a/test/sasl/Dockerfile
+++ b/test/sasl/Dockerfile
@@ -1,4 +1,4 @@
-FROM memcached:latest
+FROM memcached:1.6.44
 
 USER root
 


### PR DESCRIPTION
## Summary
Pin the floating `memcached:latest` test-service image to the concrete version it currently resolves to, for reproducible test runs.

## Images
- `memcached` `latest` → `1.6.44`

## Locations
- `docker-compose.yml:3` — service `memcached1`
- `docker-compose.yml:11` — service `memcached2`
- `docker-compose.yml:19` — service `memcached3`
- `test/sasl/Dockerfile:1` — SASL test image base

## Checks
- [x] `docker compose up -d --build` rebuilds the SASL image on the pinned base (apt packages resolve)
- [x] `pnpm build` + `pnpm test:ci` pass (612 tests, 100% statement/line coverage) against the pinned images
- Tag-only pin — no digest introduced (digest pinning is separate defense-in-depth work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqhnMb2Khr8eYnWmYbAmtd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqhnMb2Khr8eYnWmYbAmtd)_