### PR TITLE
docs: add Cursor Cloud dev environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,15 @@ Guidelines for AI coding agents (Claude, Gemini, Codex).
 - `src/node.ts` - MemcacheNode class for single server TCP connections
 - `src/ketama.ts` - Consistent hashing implementation (Ketama algorithm)
 - `test/` - Test files (Vitest)
+
+## Cursor Cloud specific instructions
+
+This is a pure Node.js library (no long-running app server); "running" it means building and exercising the client against local memcached. Standard commands live in the `## Commands` section above and in `package.json`.
+
+- Node version: the repo requires Node `>=22.19.0`. The system node at `/exec-daemon/node` is too old; `~/.bashrc` is configured to prioritize nvm's default Node 24 and `pnpm` comes from corepack. Login shells (the default) already resolve the correct `node`/`pnpm`, so no manual `nvm use` is needed.
+- Docker is required for tests but the daemon does NOT auto-start. Before running integration tests, start it once per session and make the socket usable by the repo's non-sudo scripts:
+  - `sudo dockerd > /tmp/dockerd.log 2>&1 &`
+  - `sudo chmod 666 /var/run/docker.sock`
+  - Then `pnpm test:services:start` (docker compose) brings up memcached on ports `11211`, `11212`, `11213` and a SASL server on `11215`. `pnpm test` / `pnpm test:ci` need these running or most suites fail.
+- Docker note: the daemon is configured with the `fuse-overlayfs` storage driver and `containerd-snapshotter` disabled (required for Docker 29 in this VM). This is already set in `/etc/docker/daemon.json`.
+- Known environment-only test failures: the two `should handle connection timeout` tests (`test/index.test.ts`, `test/node.test.ts`) fail here because outbound TCP to the reserved TEST-NET-1 address `192.0.2.0` connects instantly in this sandbox instead of timing out. This is a network-environment quirk, not a code bug; these pass on GitHub CI. All other tests (610) pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?**

Docs update. This adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting how to set up and run the development environment in a Cursor Cloud agent VM. No source code is changed.

Notes captured for future agents:
- Node `>=22.19.0` is required; the system `/exec-daemon/node` is too old, so `~/.bashrc` prioritizes nvm's Node 24 (pnpm via corepack).
- Docker must be started manually per session before integration tests (`sudo dockerd &`, `chmod 666` the socket), then `pnpm test:services:start` brings up memcached on `11211`-`11213` plus SASL on `11215`.
- Docker 29 in this VM uses the `fuse-overlayfs` storage driver with `containerd-snapshotter` disabled.
- Two `should handle connection timeout` tests fail only in this sandbox because outbound TCP to reserved `192.0.2.0` connects instantly instead of timing out; they pass on GitHub CI. All other 610 tests pass.

**Verification**
- `pnpm build` — succeeds (ESM + CJS + type declarations)
- `pnpm lint` — clean (Biome)
- `pnpm test` — 610/612 pass (2 env-only network-timeout failures described above)
- Hello-world smoke test against local memcached: `connect` → `set` → `get` → `incr` → `delete` all succeed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca0ee00f-9a7a-44a5-b7a6-22add20975cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca0ee00f-9a7a-44a5-b7a6-22add20975cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

