### PR TITLE
memcache - chore: defense - scaffold security docs

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -6,8 +6,8 @@ Profile: npm library · public
 
 ## 1. Security docs
 
-- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR pending)
-- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR pending)
+- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR #105 pending)
+- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR #105 pending)
 
 ## 2. CODEOWNERS and cloud bootstrap
 

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -1,0 +1,57 @@
+# Defense in Depth
+
+Tracking against https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md.
+
+Profile: npm library · public
+
+## 1. Security docs
+
+- [ ] `SECURITY.md` present — contact info + "How this repository is secured" summary (PR pending)
+- [ ] `DEFENSE_IN_DEPTH.md` present (this file) (PR pending)
+
+## 2. CODEOWNERS and cloud bootstrap
+
+- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
+
+## 3. Dependencies (pnpm)
+
+- [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-08-17 (`pnpm@11.5.2`)
+- [ ] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`
+- [ ] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline
+- [ ] `blockExoticSubdeps: true`
+- [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile`
+- [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified 2026-08-17
+- [ ] New direct dependencies get human review; prefer `~` ranges over `^`
+
+## 4. GitHub Actions
+
+- [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — verified 2026-08-17
+- [ ] Every action pinned to a full commit SHA (`npx actions-up`)
+- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install`
+- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR
+- [ ] `persist-credentials: false` on checkouts that don't push
+- [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-17
+- [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning
+- [ ] No npm tokens (or other registry credentials) in Actions secrets
+
+## 5. npm publishing — npm libraries only
+
+- [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
+- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks`
+- [ ] Maintainer promotes staged versions with 2FA (manual)
+- [ ] Drydock connected — staged releases reviewed before promotion (manual)
+- [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
+- [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-17
+
+## 6. Security tooling
+
+- [ ] Aikido runs on every build
+- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release`
+- [ ] Socket reviews every PR that changes dependencies
+
+## 7. Repository lockdown
+
+- [ ] `lockdown-repo.sh` applied; `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable)
+- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
+- [ ] Recovery codes stored offline in a password manager (manual)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -46,9 +46,9 @@ Profile: npm library · public
 
 ## 6. Security tooling
 
-- [ ] Aikido runs on every build
+- [x] Aikido runs on every build — verified 2026-08-17 (GitHub app; skipped docs-only PRs)
 - [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release`
-- [ ] Socket reviews every PR that changes dependencies
+- [x] Socket reviews every PR that changes dependencies — verified 2026-08-17 (GitHub app on PRs)
 
 ## 7. Repository lockdown
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,23 @@
 # Security Policy
 
-We work hard to keep up to date with continual updates to this project. If there are concerns / security related issues please create an issue as soon as possible with how to replicate. If it is urgent please email me@jaredwray.com and I will respond as soon as possible as we take these matters seriously. 
+We take security seriously and work to keep this project up to date. If you discover a security vulnerability, please report it **privately** so we can investigate and ship a fix before the issue becomes public.
+
+## Reporting a vulnerability
+
+Please use one of the following private channels — **do not open a public issue, pull request, or discussion** for security concerns:
+
+1. **Preferred:** open a private report via GitHub's [Privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) flow on this repository's **Security** tab.
+2. **Email:** send the details to me@jaredwray.com. If the issue is urgent, include `[SECURITY]` in the subject line and we will respond as soon as possible.
+
+When reporting, please include as much of the following as you can:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a proof of concept.
+- The affected version(s) and platform.
+- Any suggested remediation, if you have one.
+
+We will acknowledge receipt, work with you on a coordinated disclosure timeline, and credit you in the advisory once a fix is published unless you ask to remain anonymous.
+
+## How this repository is secured
+
+This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md) hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place will be listed here as each section of that checklist lands.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scaffold the public security policy and the defense-in-depth checklist so this repo can be hardened one item at a time against the latest catalog.

## Status update

`DEFENSE_IN_DEPTH.md`: § 1 Security docs → (PR #105 pending)

Reconciled already-true items (no matching PR): `packageManager` pin (`pnpm@11.5.2`), no Dependabot config, workflow `permissions: contents: read`, no `pull_request_target`, accurate `repository.url`, Aikido GitHub app on builds, Socket GitHub app on PRs. Existing pnpm cooldown is 2 days (`2880`), not the catalog's 7-day baseline — that stays unchecked for a later PR.

## Changes

- Replace `SECURITY.md` with private-disclosure reporting plus a "How this repository is secured" summary (no control bullets until those sections land).
- Add `DEFENSE_IN_DEPTH.md` from the current catalog (`Profile: npm library · public`).

## Verification

- [x] `SECURITY.md` and `DEFENSE_IN_DEPTH.md` present and internally linked
- [ ] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage — docs-only; no code or test changes

## Reference

defense-in-depth-nodejs § 1

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf50a337-d254-4ef9-bb57-73d4b0d12602?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf50a337-d254-4ef9-bb57-73d4b0d12602&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

