### PR TITLE
memcache - chore: defense - bootstrap Aikido Safe Chain

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "bash ./scripts/setup-cloud-environment.sh"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Node.js",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:latest",
+  "postCreateCommand": "bash ./scripts/setup-cloud-environment.sh"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,11 @@ This is a pure Node.js library (no long-running app server); "running" it means 
   - Then `pnpm test:services:start` (docker compose) brings up memcached on ports `11211`, `11212`, `11213` and a SASL server on `11215`. `pnpm test` / `pnpm test:ci` need these running or most suites fail.
 - Docker note: the daemon is configured with the `fuse-overlayfs` storage driver and `containerd-snapshotter` disabled (required for Docker 29 in this VM). This is already set in `/etc/docker/daemon.json`.
 - Known environment-only test failures: the two `should handle connection timeout` tests (`test/index.test.ts`, `test/node.test.ts`) fail here because outbound TCP to the reserved TEST-NET-1 address `192.0.2.0` connects instantly in this sandbox instead of timing out. This is a network-environment quirk, not a code bug; these pass on GitHub CI. All other tests (610) pass.
+
+## Safe Chain
+
+Package installs in this environment go through Aikido Safe Chain shims. Never bypass them:
+
+- Keep `~/.safe-chain/shims` first on `PATH`.
+- Do not call unshimmed `npm`, `pnpm`, `npx`, or `pnpx`.
+- Do not install packages with `curl | sh` or by pointing at a package manager outside the shim directory.

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -12,7 +12,7 @@ Profile: npm library · public
 ## 2. CODEOWNERS and cloud bootstrap
 
 - [x] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names — PR #106
-- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR pending)
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR #107 pending)
 
 ## 3. Dependencies (pnpm)
 

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -11,8 +11,8 @@ Profile: npm library · public
 
 ## 2. CODEOWNERS and cloud bootstrap
 
-- [ ] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names (PR #106 pending)
-- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile)
+- [x] `.github/CODEOWNERS` covers `/.github/`, `/.cursor/`, `/.devcontainer/`, `/scripts/` with owners the maintainer names — PR #106
+- [ ] Codespaces and Cursor Cloud Agents bootstrap Aikido Safe Chain via scripts/setup-cloud-environment.sh (--ci shims, frozen lockfile) (PR pending)
 
 ## 3. Dependencies (pnpm)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,4 +20,6 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 
 ## How this repository is secured
 
-This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md) hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place will be listed here as each section of that checklist lands.
+This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md) hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
+
+- Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.

--- a/scripts/setup-cloud-environment.sh
+++ b/scripts/setup-cloud-environment.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# setup-cloud-environment.sh — Aikido Safe Chain bootstrap for Codespaces and Cursor Cloud Agents.
+#
+# Fail closed: never install dependencies unless Safe Chain shims are on PATH.
+# Copied into the target repo as scripts/setup-cloud-environment.sh.
+
+set -euo pipefail
+
+export SAFE_CHAIN_VERSION="1.5.15"
+SAFE_CHAIN_INSTALLER_SHA256="de0565e3d6346407a604e84e639e95fea8758748063da2216bbfdca5feda5dd2"
+SAFE_CHAIN_INSTALLER_URL="https://github.com/AikidoSec/safe-chain/releases/download/${SAFE_CHAIN_VERSION}/install-safe-chain.sh"
+SAFE_CHAIN_SHIMS="${HOME}/.safe-chain/shims"
+SAFE_CHAIN_BIN="${HOME}/.safe-chain/bin"
+
+if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+  cd "$git_root"
+fi
+
+if [[ ! -f pnpm-lock.yaml ]]; then
+  echo "error: pnpm-lock.yaml is required; refusing to install without a frozen lockfile" >&2
+  exit 1
+fi
+
+if [[ -f package.json ]] && grep -q '"packageManager"' package.json && command -v corepack >/dev/null; then
+  corepack enable
+fi
+
+if ! command -v pnpm >/dev/null; then
+  echo "error: pnpm is required on PATH before Safe Chain can wrap it" >&2
+  exit 1
+fi
+
+installer=$(mktemp)
+trap 'rm -f "$installer"' EXIT
+
+curl -fsSL "$SAFE_CHAIN_INSTALLER_URL" -o "$installer"
+echo "${SAFE_CHAIN_INSTALLER_SHA256}  ${installer}" | sha256sum -c -
+
+sh "$installer" --ci
+
+export PATH="${SAFE_CHAIN_SHIMS}:${SAFE_CHAIN_BIN}:${PATH}"
+
+persist_shim_path() {
+  local rc="$1"
+  local line="export PATH=\"${SAFE_CHAIN_SHIMS}:${SAFE_CHAIN_BIN}:\$PATH\""
+  if [[ -f "$rc" ]] && grep -Fq ".safe-chain/shims" "$rc"; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$rc")"
+  printf '\n# Aikido Safe Chain shims\n%s\n' "$line" >> "$rc"
+}
+
+persist_shim_path "${HOME}/.profile"
+persist_shim_path "${HOME}/.bashrc"
+persist_shim_path "${HOME}/.zshrc"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  printf '%s\n' "$SAFE_CHAIN_SHIMS" >> "$GITHUB_PATH"
+  printf '%s\n' "$SAFE_CHAIN_BIN" >> "$GITHUB_PATH"
+fi
+
+pnpm safe-chain-verify
+pnpm install --frozen-lockfile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bootstrap Aikido Safe Chain on Codespaces and Cursor Cloud Agents so package installs go through pinned shims and a frozen lockfile.

## Status update

`DEFENSE_IN_DEPTH.md`: § 2 Safe Chain → (PR #107 pending); CODEOWNERS → PR #106 (merged)

## Changes

- Add `scripts/setup-cloud-environment.sh` (Safe Chain 1.5.15, installer SHA-256 pinned, `--ci` shims, `pnpm install --frozen-lockfile`)
- Add `.devcontainer/devcontainer.json` and `.cursor/environment.json` invoking that script
- Append the Safe Chain section to `AGENTS.md`
- List the live Safe Chain control in `SECURITY.md`
- Reconcile CODEOWNERS after PR #106

No leftover PMG / VM-egress catalog line was present.

## Verification

- [x] `.devcontainer/devcontainer.json` and `.cursor/environment.json` are valid JSON
- [x] `bash ./scripts/setup-cloud-environment.sh` — installer SHA verified, `pnpm safe-chain-verify` OK, frozen lockfile install succeeded
- [ ] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines

## Reference

defense-in-depth-nodejs § 2

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf50a337-d254-4ef9-bb57-73d4b0d12602?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf50a337-d254-4ef9-bb57-73d4b0d12602&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

