### PR TITLE
memcache - chore: defense - freeze CI installs behind sfw

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
@@ -22,7 +27,7 @@ jobs:
         node-version: 24
         cache: 'pnpm'
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
     - name: Build
       run: pnpm build
 
@@ -31,6 +36,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
@@ -38,7 +48,7 @@ jobs:
         node-version: 24
         cache: 'pnpm'
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
     - name: Test Services
       run: pnpm test:services:start
     - name: Build
@@ -51,6 +61,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
@@ -58,7 +73,7 @@ jobs:
         node-version: 24
         cache: 'pnpm'
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
     - name: Test Services
       run: pnpm test:services:start
     - name: Build

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -22,7 +22,7 @@ jobs:
         node-version: 24
         cache: 'pnpm'
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Build
       run: pnpm build
 
@@ -38,7 +38,7 @@ jobs:
         node-version: 24
         cache: 'pnpm'
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Test Services
       run: pnpm test:services:start
     - name: Build
@@ -58,7 +58,7 @@ jobs:
         node-version: 24
         cache: 'pnpm'
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Test Services
       run: pnpm test:services:start
     - name: Build

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -41,6 +41,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v7
 
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -16,6 +16,11 @@ jobs:
     - uses: actions/checkout@v7
       with:
         persist-credentials: false
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
@@ -23,7 +28,7 @@ jobs:
         node-version: 24
 
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
 
     - name: Build Website
       run: pnpm website:build

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -23,7 +23,7 @@ jobs:
         node-version: 24
 
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
 
     - name: Build Website
       run: pnpm website:build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,13 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
     - name: Build
       run: pnpm build
 
@@ -28,13 +33,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
     - name: Test Services
       run: pnpm test:services:start
     - name: Build
@@ -50,13 +60,18 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v7
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - uses: pnpm/action-setup@v6
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
         node-version: 24
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
     - name: Build
       run: pnpm build
     - name: Publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       with:
         node-version: 24
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Build
       run: pnpm build
 
@@ -34,7 +34,7 @@ jobs:
       with:
         node-version: 24
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Test Services
       run: pnpm test:services:start
     - name: Build
@@ -56,7 +56,7 @@ jobs:
       with:
         node-version: 24
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Build
       run: pnpm build
     - name: Publish

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
     - name: Test Services
       run: pnpm test:services:start
     - name: Build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,11 @@ jobs:
         node-version: ['22', '24', '26']
     steps:
     - uses: actions/checkout@v7
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
     - uses: pnpm/action-setup@v6
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v6
@@ -25,7 +30,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'
     - name: Install Dependencies
-      run: pnpm install --frozen-lockfile
+      run: sfw pnpm install --frozen-lockfile
     - name: Test Services
       run: pnpm test:services:start
     - name: Build

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -19,8 +19,8 @@ Profile: npm library · public
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-08-17 (`pnpm@11.5.2`)
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — PR #108
 - [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — PR #109
-- [ ] `blockExoticSubdeps: true` (PR #110 pending)
-- [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile`
+- [x] `blockExoticSubdeps: true` — PR #110
+- [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` (PR pending)
 - [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified 2026-08-17
 - [ ] New direct dependencies get human review; prefer `~` ranges over `^`
 

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -28,7 +28,7 @@ Profile: npm library · public
 
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — verified 2026-08-17
 - [ ] Every action pinned to a full commit SHA (`npx actions-up`)
-- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install`
+- [ ] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` (PR #111 pending)
 - [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR
 - [ ] `persist-credentials: false` on checkouts that don't push
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-17

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -20,7 +20,7 @@ Profile: npm library · public
 - [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — PR #108
 - [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — PR #109
 - [x] `blockExoticSubdeps: true` — PR #110
-- [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` (PR pending)
+- [ ] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` (PR #111 pending)
 - [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified 2026-08-17
 - [ ] New direct dependencies get human review; prefer `~` ranges over `^`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Install Socket Firewall on every CI job and run `sfw pnpm install --frozen-lockfile` so dependency installs cannot bypass the wrapper.

## Status update

`DEFENSE_IN_DEPTH.md`: § 3 frozen lockfile → (PR #111 pending); § 4 Socket Firewall → (PR #111 pending); `blockExoticSubdeps` → PR #110 (merged)

## Changes

- `tests.yaml`, `code-coverage.yaml`, `release.yaml`, `deploy-site.yaml`, `codeql.yaml`: SHA-pinned `SocketDev/action` (`v1.3.2`, `firewall-version: 1.15.0`) immediately after checkout
- Every `pnpm install` is now `sfw pnpm install --frozen-lockfile`

## Verification

- [x] Every CI `pnpm install` is `sfw pnpm install --frozen-lockfile`
- [x] Every workflow job installs Socket Firewall after checkout
- [ ] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines

## Reference

defense-in-depth-nodejs § 3 and § 4

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf50a337-d254-4ef9-bb57-73d4b0d12602?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf50a337-d254-4ef9-bb57-73d4b0d12602&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

