### PR TITLE
memcache - chore: defense - stage npm releases from CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,5 +83,12 @@ jobs:
       run: sfw pnpm install --frozen-lockfile
     - name: Build
       run: pnpm build
-    - name: Publish
-      run: pnpm publish --provenance --no-git-checks
+    - name: Pack
+      run: |
+        mkdir -p packed
+        pnpm pack --pack-destination packed
+        ls -la packed
+    - name: Stage publish
+      # pnpm ≥ 11.3. --no-git-checks: git-checks run even for a tarball and
+      # fail on a detached release-tag checkout and on the untracked pack output.
+      run: pnpm stage publish ./packed/*.tgz --access public --provenance --no-git-checks

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -29,16 +29,16 @@ Profile: npm library · public
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — verified 2026-08-17
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — PR #113
 - [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` — PR #111
-- [ ] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR (PR #116 pending)
-- [ ] `persist-credentials: false` on checkouts that don't push (PR #116 pending)
+- [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #116
+- [x] `persist-credentials: false` on checkouts that don't push — PR #116
 - [x] No `pull_request_target` on workflows that run untrusted PR code — verified 2026-08-17
-- [ ] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning (PR #116 pending)
+- [x] Artifact-publishing workflows disable `actions/setup-node` default caching (`package-manager-cache: false`) to prevent cache poisoning — PR #116
 - [x] No npm tokens (or other registry credentials) in Actions secrets — verified 2026-08-18 (OIDC `id-token` on publish; no `NPM_TOKEN` in workflows)
 
 ## 5. npm publishing — npm libraries only
 
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks`
+- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR pending)
 - [ ] Maintainer promotes staged versions with 2FA (manual)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -38,7 +38,7 @@ Profile: npm library · public
 ## 5. npm publishing — npm libraries only
 
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR pending)
+- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR #117 pending)
 - [ ] Maintainer promotes staged versions with 2FA (manual)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,4 +24,5 @@ This repository follows the [defense-in-depth](https://github.com/jaredwray/agen
 
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - CI runs with read-only permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.
+- npm CI packs a tarball and stages it with `pnpm stage publish`; it does not publish live from the workflow.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switch the release workflow from live `pnpm publish` to pack + `pnpm stage publish`, so CI can only stage an artifact.

## Status update

`DEFENSE_IN_DEPTH.md`: § 5 stage publish → (PR #117 pending); § 4 zizmor / persist-credentials / publish-job cache disable → PR #116 (merged)

## Changes

- `release.yaml` publish job: `pnpm pack --pack-destination packed` then `pnpm stage publish ./packed/*.tgz --access public --provenance --no-git-checks`
- Keep the existing build → test → publish job graph (Aikido release gate is the next catalog item)
- Note the live staging control in `SECURITY.md`

npmjs.com still needs the trusted publisher set to **stage-only** (manual). Drydock and 2FA promotion are also manual.

## Verification

- [x] `zizmor .github/workflows/release.yaml` — no findings
- [ ] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines

## Reference

defense-in-depth-nodejs § 5

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf50a337-d254-4ef9-bb57-73d4b0d12602?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf50a337-d254-4ef9-bb57-73d4b0d12602&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

