### PR TITLE
memcache - chore: defense - gate staged npm publish on Aikido scan-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,39 @@ permissions:
   contents: read
 
 jobs:
+  aikido-gate:
+    name: Aikido release gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Install Socket Firewall
+      uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+      with:
+        mode: firewall-free
+        firewall-version: "1.15.0"
+    - name: Set up Node.js
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24
+        package-manager-cache: false
+    - name: Install Aikido CI client
+      # zizmor: ignore[adhoc-packages] pinned Aikido CI client for the release gate
+      run: sfw npm install --global @aikidosec/ci-api-client@1.0.17
+    # Fails on new SAST/IaC/secrets findings. The API key comes from Aikido's
+    # Continuous Integration settings — it grants no publish authority.
+    - name: Run Aikido release scan
+      env:
+        REPO_NAME: ${{ github.event.repository.name }}
+        AIKIDO_CLIENT_API_KEY: ${{ secrets.AIKIDO_CLIENT_API_KEY }}
+      run: >
+        aikido-api-client scan-release
+        "$REPO_NAME" "$GITHUB_SHA"
+        --apikey "$AIKIDO_CLIENT_API_KEY"
+        --fail-on-sast-scan --fail-on-iac-scan --fail-on-secrets-scan
+
   build:
+    needs: [aikido-gate]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -59,7 +91,7 @@ jobs:
       run: pnpm test:ci
 
   publish:
-    needs: test
+    needs: [test, aikido-gate]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -47,7 +47,7 @@ Profile: npm library · public
 ## 6. Security tooling
 
 - [x] Aikido runs on every build — verified 2026-08-17 (GitHub app; skipped docs-only PRs)
-- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR pending)
+- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR #118 pending)
 - [x] Socket reviews every PR that changes dependencies — verified 2026-08-17 (GitHub app on PRs)
 
 ## 7. Repository lockdown

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -38,7 +38,7 @@ Profile: npm library · public
 ## 5. npm publishing — npm libraries only
 
 - [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
-- [ ] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` (PR #117 pending)
+- [x] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` — PR #117
 - [ ] Maintainer promotes staged versions with 2FA (manual)
 - [ ] Drydock connected — staged releases reviewed before promotion (manual)
 - [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
@@ -47,7 +47,7 @@ Profile: npm library · public
 ## 6. Security tooling
 
 - [x] Aikido runs on every build — verified 2026-08-17 (GitHub app; skipped docs-only PRs)
-- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release`
+- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR pending)
 - [x] Socket reviews every PR that changes dependencies — verified 2026-08-17 (GitHub app on PRs)
 
 ## 7. Repository lockdown

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,5 +24,5 @@ This repository follows the [defense-in-depth](https://github.com/jaredwray/agen
 
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - CI runs with read-only permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.
-- npm CI packs a tarball and stages it with `pnpm stage publish`; it does not publish live from the workflow.
+- npm CI packs a tarball and stages it with `pnpm stage publish`; it does not publish live from the workflow. Staging waits on a passing Aikido `scan-release` of the commit (SAST, IaC, and secrets).
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add an Aikido `scan-release` job that `build` and `publish` both `needs:`, so nothing is packed and staged while new SAST, IaC, or secrets findings are open.

## Status update

`DEFENSE_IN_DEPTH.md`: § 6 Aikido release gate → (PR #118 pending)

## Changes

- New `aikido-gate` job in `release.yaml`: Socket Firewall, Node 24, pinned `@aikidosec/ci-api-client@1.0.17`, then `aikido-api-client scan-release` with `--fail-on-sast-scan --fail-on-iac-scan --fail-on-secrets-scan`
- `build` `needs: [aikido-gate]`; `publish` `needs: [test, aikido-gate]`
- Note the live gate in `SECURITY.md`

The repo secret `AIKIDO_CLIENT_API_KEY` must exist (Aikido Continuous Integration settings). It grants no publish authority.

## Verification

- [x] `zizmor .github/workflows/release.yaml` — no findings
- [ ] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines

## Reference

defense-in-depth-nodejs § 6

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf50a337-d254-4ef9-bb57-73d4b0d12602?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf50a337-d254-4ef9-bb57-73d4b0d12602&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

