### PR TITLE
memcache - chore: defense - record repository lockdown

### DIFF
--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -17,16 +17,17 @@ Profile: npm library · public
 ## 3. Dependencies (pnpm)
 
 - [x] `packageManager: pnpm@11.3+` pinned in `package.json` — verified 2026-08-17 (`pnpm@11.5.2`)
-- [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false` — PR #108
+- [x] 7-day cooldown: `minimumReleaseAge: 10080`, `minimumReleaseAgeStrict: true`, `minimumReleaseAgeIgnoreMissingTime: false`; no first-party `minimumReleaseAgeExclude` — PR #108
+- [ ] `trustPolicy: no-downgrade`; no first-party `trustPolicyExclude`
 - [x] Lifecycle scripts blocked: `strictDepBuilds: true`, `dangerouslyAllowAllBuilds: false`, `allowBuilds: {}` baseline — PR #109
 - [x] `blockExoticSubdeps: true` — PR #110
 - [x] Lockfile committed; CI installs with `pnpm install --frozen-lockfile` — PR #111
 - [x] No `.github/dependabot.yml`; other dependency-update tools (if any) open PRs only — never auto-merge — verified 2026-08-17
-- [x] New direct dependencies get human review; prefer `~` ranges over `^` — skipped converting to `~`; project keeps `^` (maintainer 2026-08-18)
 
 ## 4. GitHub Actions
 
 - [x] `permissions: contents: read` (or `{}` + per-job grants) on every workflow — verified 2026-08-17
+- [x] No `contents: write` except jobs whose purpose is mutating the repo (GitHub Release, Changesets version PR); generated output is a workflow artifact, never committed back from CI — verified 2026-08-18
 - [x] Every action pinned to a full commit SHA (`npx actions-up`) — PR #113
 - [x] Every job installs Socket Firewall (`SocketDev/action` SHA-pinned, `firewall-version` pinned); `pnpm install` / `npm install` run as `sfw pnpm install` / `sfw npm install` — PR #111
 - [x] `.github/workflows/check-workflows.yaml` lints workflows with zizmor on every PR — PR #116
@@ -47,11 +48,11 @@ Profile: npm library · public
 ## 6. Security tooling
 
 - [x] Aikido runs on every build — verified 2026-08-17 (GitHub app; skipped docs-only PRs)
-- [ ] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` (PR #118 pending)
+- [x] Aikido release gate: the release workflow's stage-publish job `needs:` a passing `scan-release` — PR #118
 - [x] Socket reviews every PR that changes dependencies — verified 2026-08-17 (GitHub app on PRs)
 
 ## 7. Repository lockdown
 
-- [ ] `lockdown-repo.sh` applied; `--check` with `--required-checks` and `--allowed-actions` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable)
+- [x] `lockdown-repo.sh` applied; `--check` with `--required-checks "test,zizmor"` and `--allowed-actions "pnpm/*,codecov/*"` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable) — applied 2026-08-18 (PR pending)
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -38,11 +38,11 @@ Profile: npm library · public
 
 ## 5. npm publishing — npm libraries only
 
-- [ ] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual)
+- [x] OIDC trusted publishing configured **stage-only** on npmjs.com for the publish workflow — it can stage, never publish live (manual) — maintainer 2026-08-18
 - [x] `.github/workflows/release.yaml` packs then stages with `pnpm stage publish ./packed/*.tgz --no-git-checks` — PR #117
-- [ ] Maintainer promotes staged versions with 2FA (manual)
-- [ ] Drydock connected — staged releases reviewed before promotion (manual)
-- [ ] No direct publish rights: package requires 2FA and disallows tokens (manual)
+- [x] Maintainer promotes staged versions with 2FA (manual) — maintainer 2026-08-18
+- [x] Drydock connected — staged releases reviewed before promotion (manual) — maintainer 2026-08-18
+- [x] No direct publish rights: package requires 2FA and disallows tokens (manual) — maintainer 2026-08-18
 - [x] `package.json` `repository.url` accurate so provenance maps to this repo — verified 2026-08-17
 
 ## 6. Security tooling

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -53,6 +53,6 @@ Profile: npm library · public
 
 ## 7. Repository lockdown
 
-- [x] `lockdown-repo.sh` applied; `--check` with `--required-checks "test,zizmor"` and `--allowed-actions "pnpm/*,codecov/*"` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable) — applied 2026-08-18 (PR pending)
+- [x] `lockdown-repo.sh` applied; `--check` with `--required-checks "test,zizmor"` and `--allowed-actions "pnpm/*,codecov/*"` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable) — applied 2026-08-18; PR #119 pending
 - [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
 - [ ] Recovery codes stored offline in a password manager (manual)

--- a/DEFENSE_IN_DEPTH.md
+++ b/DEFENSE_IN_DEPTH.md
@@ -54,5 +54,5 @@ Profile: npm library · public
 ## 7. Repository lockdown
 
 - [x] `lockdown-repo.sh` applied; `--check` with `--required-checks "test,zizmor"` and `--allowed-actions "pnpm/*,codecov/*"` passes (PRs required on the default branch, merges blocked unless required status checks pass, tag ruleset, fork-PR approval, read-only workflow tokens, Actions allowlist, secret scanning, Dependabot disabled, private vulnerability reporting as applicable) — applied 2026-08-18; PR #119 pending
-- [ ] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual)
-- [ ] Recovery codes stored offline in a password manager (manual)
+- [x] Phishing-resistant 2FA (passkeys / hardware keys) on the GitHub and npm accounts (manual) — maintainer 2026-08-18
+- [x] Recovery codes stored offline in a password manager (manual) — maintainer 2026-08-18

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,10 @@ We will acknowledge receipt, work with you on a coordinated disclosure timeline,
 
 This repository follows the [defense-in-depth](https://github.com/jaredwray/agentic/blob/main/skills/security/defense-in-depth-nodejs/SKILL.md) hardening checklist; progress is tracked in [DEFENSE_IN_DEPTH.md](./DEFENSE_IN_DEPTH.md). Measures currently in place:
 
+- All changes land through pull requests — direct pushes to `main` are blocked, and merging requires passing status checks (`test`, `zizmor`).
+- Tags (and therefore releases) can only be created by repository admins.
+- Workflow runs from outside collaborators always require maintainer approval, and only allowlisted GitHub Actions can run.
+- CI runs with read-only permissions (no job has `contents: write`); generated output is an artifact, never committed back; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
-- CI runs with read-only permissions; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.
-- npm CI packs a tarball and stages it with `pnpm stage publish`; it does not publish live from the workflow. Staging waits on a passing Aikido `scan-release` of the commit (SAST, IaC, and secrets).
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.
+- npm CI packs a tarball and stages it with `pnpm stage publish`; it does not publish live from the workflow. Staging waits on a passing Aikido `scan-release` of the commit (SAST, IaC, and secrets).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,4 +28,4 @@ This repository follows the [defense-in-depth](https://github.com/jaredwray/agen
 - CI runs with read-only permissions (no job has `contents: write`); generated output is an artifact, never committed back; every action is pinned to a full commit SHA; Socket Firewall (`sfw`) wraps `pnpm install` / `npm install`; workflows are security-linted with zizmor on every PR.
 - Codespaces and Cursor Cloud Agents install through Aikido Safe Chain; package-manager shims must not be bypassed.
 - Dependencies install through pnpm with a 7-day cooldown on new versions, and lifecycle scripts are blocked by default. Socket reviews every dependency change; Aikido scans every build.
-- npm CI packs a tarball and stages it with `pnpm stage publish`; it does not publish live from the workflow. Staging waits on a passing Aikido `scan-release` of the commit (SAST, IaC, and secrets).
+- npm releases are staged, never published directly: CI publishes via stage-only OIDC trusted publishing, Drydock reviews the exact staged artifact, and a maintainer promotes it with 2FA. There are no npm tokens. Staging waits on a passing Aikido `scan-release` of the commit (SAST, IaC, and secrets).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Record the applied GitHub repository lockdown after a passing admin `--check`, and list those controls in `SECURITY.md`.

## Status update

`DEFENSE_IN_DEPTH.md`: § 7 `lockdown-repo.sh` → (PR #119 pending); § 7 phishing-resistant 2FA and offline recovery codes → maintainer 2026-08-18; § 5 stage-only OIDC, 2FA promotion, Drydock, package 2FA / no tokens → maintainer 2026-08-18; § 6 Aikido release gate → PR #118 (merged)

## Changes

- Check off lockdown: `--required-checks "test,zizmor"` and `--allowed-actions "pnpm/*,codecov/*"`
- Add live lockdown bullets to `SECURITY.md` (PRs required, admin-only tags, fork-PR approval, Actions allowlist)
- Check off phishing-resistant 2FA and offline recovery codes (maintainer)
- Check off § 5 npm manuals (stage-only trusted publisher, 2FA promotion, Drydock, package 2FA / no tokens) and expand the `SECURITY.md` npm bullet to match
- Align the checklist with the current catalog: add `trustPolicy: no-downgrade` (still open), add the no-`contents: write` / no CI commit-back item (already true), drop the retired “prefer `~` ranges” line

## Verification

- [x] Maintainer `--check` (admin): all applicable settings in the desired state
- [ ] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines

## Reference

defense-in-depth-nodejs § 7

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf50a337-d254-4ef9-bb57-73d4b0d12602?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf50a337-d254-4ef9-bb57-73d4b0d12602&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

