### PR TITLE
fix: emit memcaches:// from MemcacheNode.uri when TLS is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,10 +323,11 @@ Remove a node from the cluster.
 ### `getNodesByKey(key: string): Promise<MemcacheNode[]>`
 Get the nodes for a given key using consistent hashing. Automatically connects to nodes if not already connected.
 
-### `parseUri(uri: string): { host: string; port: number }`
+### `parseUri(uri: string): { host: string; port: number; secure?: boolean }`
 Parse a URI string into host and port. Supports formats:
 - Simple: `"localhost:11211"` or `"localhost"`
 - Protocol: `"memcache://localhost:11211"`, `"tcp://localhost:11211"`
+- TLS: `"memcaches://localhost:11211"` (`secure: true`; enables TLS for that node)
 - IPv6: `"[::1]:11211"` or `"memcache://[2001:db8::1]:11212"`
 - Unix socket: `"/var/run/memcached.sock"` or `"unix:///var/run/memcached.sock"`
 
@@ -1177,6 +1178,9 @@ Notes:
 - `tls: true` / `tls: {}` both enable TLS with default trust; certificate
   verification is always on (standard Node behavior). To connect to a server
   with a self-signed cert, pass its CA — do not disable verification.
+- `node.uri` uses `memcaches://` when TLS is enabled, so passing it back into
+  `addNode()` or the constructor keeps TLS on even without a client-level
+  `tls` option.
 - Auto-discovery's configuration-endpoint connection does not use TLS yet;
   for ElastiCache node-based clusters with in-transit encryption, connect to
   node endpoints directly.

--- a/src/node.ts
+++ b/src/node.ts
@@ -142,10 +142,13 @@ export class MemcacheNode extends Hookified {
 	}
 
 	/**
-	 * Get the full uri like memcache://localhost:11211
+	 * Get the full URI, e.g. `memcache://localhost:11211`.
+	 * TLS-enabled nodes use `memcaches://` so the URI round-trips through
+	 * `parseUri()` / `addNode()` without a client-level `tls` option.
 	 */
 	public get uri(): string {
-		return `memcache://${this.id}`;
+		const scheme = this._tls ? "memcaches" : "memcache";
+		return `${scheme}://${this.id}`;
 	}
 
 	/**

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -58,6 +58,30 @@ describe("MemcacheNode", () => {
 			expect(testNode.uri).toBe("memcache:///var/run/memcached.sock");
 		});
 
+		it("should generate memcaches:// uri when TLS is enabled", () => {
+			expect(new MemcacheNode("localhost", 11211, { tls: true }).uri).toBe(
+				"memcaches://localhost:11211",
+			);
+			expect(new MemcacheNode("localhost", 11211, { tls: {} }).uri).toBe(
+				"memcaches://localhost:11211",
+			);
+		});
+
+		it("should generate memcache:// uri when TLS is explicitly disabled", () => {
+			expect(new MemcacheNode("localhost", 11211, { tls: false }).uri).toBe(
+				"memcache://localhost:11211",
+			);
+		});
+
+		it("should generate memcaches:// uri for TLS IPv6 and Unix sockets", () => {
+			expect(new MemcacheNode("::1", 21211, { tls: true }).uri).toBe(
+				"memcaches://[::1]:21211",
+			);
+			expect(
+				new MemcacheNode("/var/run/memcached.sock", 0, { tls: true }).uri,
+			).toBe("memcaches:///var/run/memcached.sock");
+		});
+
 		it("should use default options if not provided", () => {
 			const testNode = new MemcacheNode("localhost", 11211);
 			expect(testNode).toBeInstanceOf(MemcacheNode);

--- a/test/tls.test.ts
+++ b/test/tls.test.ts
@@ -262,5 +262,47 @@ describe("TLS", () => {
 
 			await client.disconnect();
 		});
+
+		it("should emit memcaches:// from node.uri when client-level TLS is set", async () => {
+			const client = createTlsClient();
+			expect(client.nodes[0].uri).toBe(`memcaches://${TLS_URI}`);
+			await client.disconnect();
+		});
+
+		it("should enable TLS when constructing from a TLS node's uri without client tls", async () => {
+			const source = createTlsClient();
+			const uri = source.nodes[0].uri;
+			await source.disconnect();
+
+			// Round-trip node.uri into a client with no tls option. The
+			// handshake must fail against the test CA — proving the scheme
+			// from uri kept TLS on.
+			const client = new Memcache({
+				nodes: [uri],
+				timeout: 2000,
+			});
+
+			await expect(
+				client.set(generateKey("tls-uri-roundtrip"), generateValue(), 60),
+			).rejects.toThrow();
+
+			await client.disconnect();
+		});
+
+		it("should connect when a TLS node's uri is passed with matching CA options", async () => {
+			const source = createTlsClient();
+			const client = new Memcache({
+				nodes: [source.nodes[0].uri],
+				tls: { ca },
+			});
+			const key = generateKey("tls-uri-connect");
+			const value = generateValue();
+
+			expect(await client.set(key, value, 60)).toBe(true);
+			expect(await client.get(key)).toBe(value);
+
+			await client.disconnect();
+			await source.disconnect();
+		});
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for TLS `node.uri` after #115.

`MemcacheNode.uri` always returned `memcache://`, even when the node was created with `tls: true` or a `tls.ConnectionOptions` object. Round-tripping `node.uri` through `addNode()` or the constructor then dropped TLS unless the client also set a `tls` option.

TLS-enabled nodes now emit `memcaches://host:port`, which `parseUri()` already treats as `secure: true`.

**Changes**
- `MemcacheNode.uri` uses `memcaches://` when `tls` is truthy (`true`, `{}`, or options object); `false` / unset stay `memcache://`
- Unit tests for IPv6, Unix sockets, and `tls: false`
- Integration tests that round-trip `node.uri` into a new client (with and without a CA)
- README notes the round-trip behavior and documents `memcaches://` on `parseUri()`

**Testing**
- `pnpm build` succeeded
- All 15 TLS tests passed against local `memcached-tls` (including uri round-trip)
- Full suite: 628 passed; the two `should handle connection timeout` tests fail in this sandbox (TEST-NET-1 `192.0.2.0` connects immediately) as documented in AGENTS.md
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82dce4bc-65dc-4a15-8300-1ce7d7f746e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82dce4bc-65dc-4a15-8300-1ce7d7f746e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

