### PR TITLE
root - chore: remove writr override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  writr: 6.1.5
-
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,3 @@ minimumReleaseAgeStrict: true # fail instead of falling back to a too-new versio
 minimumReleaseAgeIgnoreMissingTime: false # missing publish-time metadata fails closed
 blockExoticSubdeps: true
 trustPolicy: no-downgrade # fail if a later version has weaker trust evidence
-# writr@6.1.2 has no provenance; 6.1.3+ do. Pin past the trust downgrade.
-overrides:
-  writr: 6.1.5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Maintenance (dependency override cleanup)

## Summary
Remove the `writr@6.1.5` pnpm override. `docula@2.2.0` already resolves `writr` to `6.1.5`, so the pin is no longer needed.

## Changes
- Drop the `writr` override from `pnpm-workspace.yaml` and the lockfile

## Verification
- [x] `pnpm install` — `pnpm why writr` still resolves `writr@6.1.5`
- [x] `pnpm build`
- [x] `pnpm test` — 628 passed; the two `should handle connection timeout` tests fail only in this sandbox (TEST-NET-1 connects immediately), matching AGENTS.md. GitHub CI is the source of truth.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbeb6897-66b1-4456-b587-7a74dbe9770b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbeb6897-66b1-4456-b587-7a74dbe9770b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

