### PR TITLE
root - chore: upgrade hashery

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "wrangler": "^4.121.0"
   },
   "dependencies": {
-    "hashery": "^3.0.0",
+    "hashery": "^3.0.1",
     "hookified": "^3.0.1"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       hashery:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.1
+        version: 3.0.1
       hookified:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1852,10 +1852,6 @@ packages:
   hashery@1.5.1:
     resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
     engines: {node: '>=20'}
-
-  hashery@3.0.0:
-    resolution: {integrity: sha512-0Qf1UYWmzQ7IgJbciYmxfbH3TXGR8CJQx7syxue+XptHPXYiEO1lmkYQen2PBWLikgei0kwylMZHoUmP8G96lg==}
-    engines: {node: '>=22.18'}
 
   hashery@3.0.1:
     resolution: {integrity: sha512-jfLVt3/SEkJzW/OCSK7Bxdl+FpXYDpEE84QOU4wzKRpO7rNoafNK718Z71GPQR/ozfQmKxXS++MhbrL/eKaTow==}
@@ -4139,7 +4135,7 @@ snapshots:
       ai: 6.0.220(zod@4.4.3)
       colorette: 2.0.20
       ecto: 4.8.7(supports-color@10.2.2)
-      hashery: 3.0.0
+      hashery: 3.0.1
       ipaddr.js: 2.4.0
       jiti: 2.7.0
       serve-handler: 6.1.7
@@ -4393,10 +4389,6 @@ snapshots:
   hashery@1.5.1:
     dependencies:
       hookified: 1.15.1
-
-  hashery@3.0.0:
-    dependencies:
-      hookified: 3.0.1
 
   hashery@3.0.1:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Maintenance (runtime dependency upgrade)

## Summary
Upgrade standalone runtime `hashery` from `3.0.0` to `3.0.1` (pnpm outdated Latest under the 7-day release-age gate).

## Changes
- Bump `hashery` to `^3.0.1`

## Verification
- [x] `pnpm build`
- [x] `pnpm test` — 630 passed, 100% statement/line coverage

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbeb6897-66b1-4456-b587-7a74dbe9770b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbeb6897-66b1-4456-b587-7a74dbe9770b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

